### PR TITLE
update grafana dashboards

### DIFF
--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-etcdcluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-etcdcluster.yaml
@@ -25,12 +25,12 @@ data:
           }
         ]
       },
-      "description": "etcd sample Grafana dashboard with Prometheus",
+      "description": "etcd Grafana dashboard with Prometheus",
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 19,
-      "iteration": 1598238878567,
+      "id": 46,
+      "iteration": 1608168434446,
       "links": [],
       "panels": [
         {
@@ -54,7 +54,7 @@ data:
             "thresholdMarkers": true
           },
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 5,
             "x": 0,
             "y": 0
@@ -124,8 +124,8 @@ data:
           "datasource": "$datasource",
           "fontSize": "100%",
           "gridPos": {
-            "h": 7,
-            "w": 6,
+            "h": 8,
+            "w": 8,
             "x": 5,
             "y": 0
           },
@@ -307,6 +307,23 @@ data:
               "thresholds": [],
               "type": "number",
               "unit": "none"
+            },
+            {
+              "alias": "",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "pod",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
             }
           ],
           "targets": [
@@ -314,7 +331,7 @@ data:
               "expr": "etcd_server_is_leader{taco_cluster=~\"$taco_cluster\"}",
               "format": "table",
               "instant": true,
-              "legendFormat": "{{`{{instance}}`}}",
+              "legendFormat": "{{instance}}",
               "refId": "A"
             }
           ],
@@ -337,9 +354,9 @@ data:
           "fillGradient": 0,
           "grid": {},
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 8,
-            "x": 11,
+            "x": 13,
             "y": 0
           },
           "hiddenSeries": false,
@@ -374,7 +391,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} DB Size",
+              "legendFormat": "{{instance}} DB Size",
               "metric": "",
               "refId": "A",
               "step": 4
@@ -432,9 +449,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 10,
+            "w": 11,
             "x": 0,
-            "y": 7
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 23,
@@ -537,9 +554,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 9,
-            "x": 10,
-            "y": 7
+            "w": 10,
+            "x": 11,
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 41,
@@ -640,9 +657,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 10,
+            "w": 11,
             "x": 0,
-            "y": 14
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 22,
@@ -675,7 +692,7 @@ data:
             {
               "expr": "rate(etcd_network_client_grpc_received_bytes_total{taco_cluster=\"$taco_cluster\"}[5m])",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} Client Traffic In",
+              "legendFormat": "{{instance}} Client Traffic In",
               "metric": "etcd_network_client_grpc_received_bytes_total",
               "refId": "A",
               "step": 4
@@ -735,9 +752,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 9,
-            "x": 10,
-            "y": 14
+            "w": 10,
+            "x": 11,
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 21,
@@ -770,7 +787,7 @@ data:
             {
               "expr": "rate(etcd_network_client_grpc_sent_bytes_total{taco_cluster=\"$taco_cluster\"}[5m])",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} Client Traffic Out",
+              "legendFormat": "{{instance}} Client Traffic Out",
               "metric": "etcd_network_client_grpc_sent_bytes_total",
               "refId": "A",
               "step": 4
@@ -830,9 +847,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 10,
+            "w": 11,
             "x": 0,
-            "y": 21
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 20,
@@ -865,7 +882,7 @@ data:
             {
               "expr": "sum(rate(etcd_network_peer_received_bytes_total{taco_cluster=\"$taco_cluster\"}[5m])) by (instance)",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} Peer Traffic In",
+              "legendFormat": "{{instance}} Peer Traffic In",
               "metric": "etcd_network_peer_received_bytes_total",
               "refId": "A",
               "step": 4
@@ -927,9 +944,9 @@ data:
           "grid": {},
           "gridPos": {
             "h": 7,
-            "w": 9,
-            "x": 10,
-            "y": 21
+            "w": 10,
+            "x": 11,
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 16,
@@ -963,7 +980,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} Peer Traffic Out",
+              "legendFormat": "{{instance}} Peer Traffic Out",
               "metric": "etcd_network_peer_sent_bytes_total",
               "refId": "A",
               "step": 4
@@ -1021,9 +1038,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 10,
+            "w": 11,
             "x": 0,
-            "y": 28
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 29,
@@ -1056,7 +1073,7 @@ data:
             {
               "expr": "process_resident_memory_bytes{taco_cluster=\"$taco_cluster\"}",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} Resident Memory",
+              "legendFormat": "{{instance}} Resident Memory",
               "metric": "process_resident_memory_bytes",
               "refId": "A",
               "step": 4
@@ -1117,9 +1134,9 @@ data:
           "grid": {},
           "gridPos": {
             "h": 7,
-            "w": 9,
-            "x": 10,
-            "y": 28
+            "w": 10,
+            "x": 11,
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 3,
@@ -1152,7 +1169,7 @@ data:
               "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{taco_cluster=\"$taco_cluster\"}[5m])) by (instance, le))",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} WAL fsync",
+              "legendFormat": "{{instance}} WAL fsync",
               "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
               "refId": "A",
               "step": 4
@@ -1160,7 +1177,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{taco_cluster=\"$taco_cluster\"}[5m])) by (instance, le))",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} DB fsync",
+              "legendFormat": "{{instance}} DB fsync",
               "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
               "refId": "B",
               "step": 4
@@ -1218,9 +1235,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 10,
+            "w": 11,
             "x": 0,
-            "y": 35
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 40,
@@ -1337,9 +1354,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 9,
-            "x": 10,
-            "y": 35
+            "w": 10,
+            "x": 11,
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 19,
@@ -1374,7 +1391,7 @@ data:
             {
               "expr": "changes(etcd_server_leader_changes_seen_total{taco_cluster=\"$taco_cluster\"}[1d])",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{instance}}`}} Total Leader Elections Per Day",
+              "legendFormat": "{{instance}} Total Leader Elections Per Day",
               "metric": "etcd_server_leader_changes_seen_total",
               "refId": "A",
               "step": 2
@@ -1434,7 +1451,6 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
               "text": "Prometheus",
               "value": "Prometheus"
             },
@@ -1453,7 +1469,6 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
               "text": "skb-suy-adm01",
               "value": "skb-suy-adm01"
             },

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-f5status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-f5status.yaml
@@ -1,0 +1,1221 @@
+{{- if .Values.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-taco-f5status
+  namespace: {{ .Values.grafanaDashboard.namespace }}
+  labels:
+    {{- if $.Values.grafanaDashboard.sidecar.dashboards.label }}
+    {{ $.Values.grafanaDashboard.sidecar.dashboards.label }}: "1"
+    {{- end }}
+    app: grafana
+data:
+  taco-f5status.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "Prometheus",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "limit": 100,
+            "name": "Annotations & Alerts",
+            "showIn": 0,
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 84,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 115,
+          "panels": [],
+          "title": "Big IP Controller Utilization & Location",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 11,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 109,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(container_cpu_usage_seconds_total{taco_cluster=~\"skb-suy-adm.*\",container=~\"k8s-big.*\",namespace=\"kube-system\",pod=~\"k8s-big.*\"}[1m])",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}} : {{node}}",
+              "refId": "A",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage (skb-suy-adm01)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 1,
+          "editable": false,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 11,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 105,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "container_memory_working_set_bytes{pod=~\"k8s-bigip.*\", namespace=\"kube-system\",taco_cluster=~\"skb-suy-adm01\",image!=\"\",container!=\"POD\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}} : {{node}}",
+              "metric": "container_memory_usage_bytes",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage (skb-suy-adm01)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 11,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 107,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(container_cpu_usage_seconds_total{taco_cluster=~\"skb-suy-prd01.*\",container=~\"k8s-big.*\",namespace=\"kube-system\",pod=~\"k8s-big.*\"}[1m])",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}} : {{node}}",
+              "refId": "A",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage (skb-suy-prod01)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 1,
+          "editable": false,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 11,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 111,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "container_memory_working_set_bytes{pod=~\"k8s-bigip.*\", namespace=\"kube-system\",taco_cluster=~\"skb-suy-prd01\",image!=\"\",container!=\"POD\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}} : {{node}}",
+              "metric": "container_memory_usage_bytes",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage (skb-suy-prd01)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 11,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 103,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(container_cpu_usage_seconds_total{taco_cluster=~\"skb-ssu-prd02.*\",container=~\"k8s-big.*\",namespace=\"kube-system\",pod=~\"k8s-big.*\"}[1m])",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{ pod}} : {{node}}",
+              "refId": "A",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage (skb-ssu-pro02)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 1,
+          "editable": false,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 11,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 113,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "container_memory_working_set_bytes{pod=~\"k8s-bigip.*\", namespace=\"kube-system\",taco_cluster=~\"skb-ssu-prd02\",image!=\"\",container!=\"POD\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{ pod}} : {{node}}",
+              "metric": "container_memory_usage_bytes",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage (skb-ssu-prd02)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "id": 101,
+          "panels": [],
+          "title": "F5 Request Per Second",
+          "type": "row"
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": null,
+          "gridPos": {
+            "h": 8,
+            "w": 11,
+            "x": 0,
+            "y": 23
+          },
+          "id": 98,
+          "links": [],
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "defaults": {
+                "mappings": [
+                  {
+                    "id": 0,
+                    "op": "=",
+                    "text": "N/A",
+                    "type": 1,
+                    "value": "null"
+                  }
+                ],
+                "nullValueMode": "connected",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.6.2",
+          "targets": [
+            {
+              "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-suy-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[1m]))by(namespace) ",
+              "intervalFactor": 2,
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "수유-namespace별 RPS(1분평균)",
+          "type": "gauge"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#56A64B",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": null,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 11,
+            "y": 23
+          },
+          "id": 95,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.6.2",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "70%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(145, 255, 138, 0.26)",
+            "full": true,
+            "lineColor": "#96D98D",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-suy-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[30s]))",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "수유 RPS(30초평균)",
+          "type": "singlestat",
+          "valueFontSize": "120%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": null,
+          "gridPos": {
+            "h": 8,
+            "w": 11,
+            "x": 0,
+            "y": 31
+          },
+          "id": 94,
+          "links": [],
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "defaults": {
+                "mappings": [
+                  {
+                    "id": 0,
+                    "op": "=",
+                    "text": "N/A",
+                    "type": 1,
+                    "value": "null"
+                  }
+                ],
+                "nullValueMode": "connected",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.6.2",
+          "targets": [
+            {
+              "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-ssu-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[1m]))by(namespace) ",
+              "intervalFactor": 2,
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "성수-namespace별 RPS(1분평균)",
+          "type": "gauge"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#56A64B",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": null,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 11,
+            "y": 31
+          },
+          "id": 99,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.6.2",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "70%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(145, 255, 138, 0.26)",
+            "full": true,
+            "lineColor": "#96D98D",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-ssu-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[30s]))",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "성수 RPS(30초 평균)",
+          "type": "singlestat",
+          "valueFontSize": "120%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 39
+          },
+          "id": 76,
+          "panels": [],
+          "title": "F5 Pool Member Request (metv, scs,  common, stb)",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 23,
+            "x": 0,
+            "y": 40
+          },
+          "hiddenSeries": false,
+          "id": 77,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pluginVersion": "6.5.2",
+          "pointradius": 1,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-suy-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[30s]))by(taco_cluster, svc) ",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{taco_cluster}}:: {{svc}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "수유서비스 F5 Pool Member Request (metv, scs, common, stb)-30초 평균",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 23,
+            "x": 0,
+            "y": 54
+          },
+          "hiddenSeries": false,
+          "id": 82,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pluginVersion": "6.5.2",
+          "pointradius": 1,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-ssu-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[30s]))by(taco_cluster, svc) ",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{taco_cluster}}:: {{svc}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "성수 서비스 F5 Pool Member Request (metv, scs, common, stb)-30초 평균",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": "5m",
+      "schemaVersion": 22,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "F5 Status",
+      "uid": "taco-f5status",
+      "version": 21
+    }
+{{- end}}

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-cluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-cluster.yaml
@@ -28,8 +28,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 18,
-      "iteration": 1598238786935,
+      "id": 77,
+      "iteration": 1608168371366,
       "links": [],
       "panels": [
         {
@@ -1288,7 +1288,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -1324,7 +1324,7 @@ data:
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{status=\"true\",condition=\"Ready\",taco_cluster=~\"$taco_cluster\"}) by (node)",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -1348,6 +1348,7 @@ data:
           },
           "yaxes": [
             {
+              "decimals": null,
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1356,12 +1357,13 @@ data:
               "show": true
             },
             {
+              "decimals": null,
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": "1.25",
+              "max": "2",
               "min": "0",
-              "show": true
+              "show": false
             }
           ],
           "yaxis": {
@@ -1571,7 +1573,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_cpu_cores{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -1596,7 +1598,7 @@ data:
           "yaxes": [
             {
               "format": "short",
-              "label": null,
+              "label": "Core",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -1658,7 +1660,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_memory_bytes{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -1682,7 +1684,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "decbytes",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1790,7 +1792,7 @@ data:
               "expr": " count(count by (pod)(kube_pod_container_info{taco_cluster=~\"$taco_cluster\"}))",
               "hide": false,
               "instant": true,
-              "legendFormat": "{{`{{pod}}`}}",
+              "legendFormat": "{{pod}}",
               "refId": "A"
             },
             {
@@ -1987,7 +1989,7 @@ data:
               "expr": "count(kube_pod_container_status_waiting{taco_cluster=~\"$taco_cluster\"} !=0 ) or vector(0)",
               "hide": false,
               "instant": true,
-              "legendFormat": "{{`{{pod}}`}}",
+              "legendFormat": "{{pod}}",
               "refId": "A"
             }
           ],
@@ -2060,7 +2062,7 @@ data:
             {
               "expr": "count by(namespace,reason) (kube_pod_container_status_waiting_reason{taco_cluster=~\"$taco_cluster\"} !=0 )",
               "hide": false,
-              "legendFormat": "WAITING::{{`{{reason}}`}}::{{`{{namespace}}`}}",
+              "legendFormat": "WAITING::{{reason}}::{{namespace}}",
               "refId": "B"
             },
             {
@@ -2181,7 +2183,7 @@ data:
               "expr": "count(kube_pod_container_status_terminated_reason{reason!=\"Completed\",taco_cluster=~\"$taco_cluster\"} !=0 ) or vector(0)",
               "hide": false,
               "instant": true,
-              "legendFormat": "{{`{{pod}}`}}",
+              "legendFormat": "{{pod}}",
               "refId": "A"
             }
           ],
@@ -2255,7 +2257,7 @@ data:
               "expr": "count by(namespace,reason) (kube_pod_container_status_terminated_reason{reason!=\"Completed\",taco_cluster=~\"$taco_cluster\"} !=0 )",
               "hide": false,
               "instant": false,
-              "legendFormat": "TERMINATED::{{`{{reason}}`}}::{{`{{namespace}}`}}",
+              "legendFormat": "TERMINATED::{{reason}}::{{namespace}}",
               "refId": "A"
             }
           ],
@@ -2361,7 +2363,7 @@ data:
             {
               "expr": "(kubelet_volume_stats_used_bytes {taco_cluster=\"$taco_cluster\"} / kubelet_volume_stats_capacity_bytes {taco_cluster=\"$taco_cluster\"}) * 100 ",
               "instant": true,
-              "legendFormat": "{{`{{persistentvolumeclaim}}`}}",
+              "legendFormat": "{{persistentvolumeclaim}}",
               "refId": "A"
             }
           ],
@@ -2388,9 +2390,7 @@ data:
       "refresh": "10s",
       "schemaVersion": 22,
       "style": "dark",
-      "tags": [
-        "kubernetes"
-      ],
+      "tags": [],
       "templating": {
         "list": [
           {
@@ -2399,7 +2399,7 @@ data:
               "text": "Prometheus",
               "value": "Prometheus"
             },
-            "hide": 0,
+            "hide": 2,
             "includeAll": false,
             "label": null,
             "multi": false,
@@ -2414,7 +2414,7 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "skb-suy-adm01",
               "value": "skb-suy-adm01"
             },
@@ -2440,7 +2440,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-6h",
+        "from": "now-30m",
         "to": "now"
       },
       "timepicker": {

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-overview.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-overview.yaml
@@ -28,8 +28,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 17,
-      "iteration": 1598239141268,
+      "id": 50,
+      "iteration": 1608165048821,
       "links": [],
       "panels": [
         {
@@ -1120,7 +1120,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", taco_cluster=\"skb-suy-prd01\"})",
+              "expr": "count(up{job=\"kubelet\", taco_cluster=\"skb-suy-prd01\"})",
               "hide": false,
               "instant": true,
               "refId": "A"
@@ -1375,7 +1375,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", taco_cluster=\"skb-ssu-prd02\"})",
+              "expr": "count(up{job=\"kubelet\", taco_cluster=\"skb-ssu-prd02\"})",
               "hide": false,
               "instant": true,
               "refId": "A"
@@ -1628,7 +1628,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", taco_cluster=\"skb-suy-adm01\"})",
+              "expr": "count(up{job=\"kubelet\", taco_cluster=\"skb-suy-adm01\"})",
               "hide": false,
               "instant": true,
               "refId": "A"
@@ -1882,7 +1882,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": " count(count by (pod)(kube_pod_container_info{taco_cluster=~\"skb-suy-prd01\"}))",
+              "expr": "sum(kube_pod_info{taco_cluster=~\"skb-suy-prd01\", created_by_kind != \"Workflow\"})",
               "instant": false,
               "refId": "A"
             }
@@ -1966,7 +1966,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": " count(count by (pod)(kube_pod_container_info{taco_cluster=~\"skb-ssu-prd02\"}))",
+              "expr": "sum(kube_pod_info{taco_cluster=~\"skb-ssu-prd02\", created_by_kind != \"Workflow\"})",
               "instant": false,
               "refId": "A"
             }
@@ -2050,7 +2050,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": " count(count by (pod)(kube_pod_container_info{taco_cluster=~\"skb-suy-adm01\"}))",
+              "expr": "sum(kube_pod_info{taco_cluster=~\"skb-suy-adm01\", created_by_kind != \"Workflow\"})",
               "instant": false,
               "refId": "A"
             }
@@ -2117,11 +2117,11 @@ data:
           "pluginVersion": "6.6.2",
           "targets": [
             {
-              "expr": "sort_desc (count by (node) (kube_pod_info{taco_cluster=\"skb-suy-prd01\"}))",
+              "expr": "sort_desc (count by (node) (kube_pod_info{taco_cluster=\"skb-suy-prd01\", created_by_kind != \"Workflow\"}))",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -2178,7 +2178,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -2237,7 +2237,7 @@ data:
               "expr": "sort_desc (count by (node) (kube_pod_info{taco_cluster=\"skb-ssu-prd02\", created_by_kind != \"Workflow\"}))",
               "format": "time_series",
               "instant": true,
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -2294,7 +2294,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -2353,7 +2353,7 @@ data:
               "expr": "sort_desc (count by (node) (kube_pod_info{taco_cluster=\"skb-suy-adm01\", created_by_kind != \"Workflow\"}))",
               "format": "time_series",
               "instant": true,
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -2410,7 +2410,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -2512,7 +2512,7 @@ data:
             {
               "expr": "kube_deployment_spec_replicas{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
               "instant": true,
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -2734,7 +2734,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_spec_replicas{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -2823,7 +2823,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -3081,7 +3081,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_available{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -3170,7 +3170,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_unavailable{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}  ",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -3271,7 +3271,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_cpu_cores{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -3358,7 +3358,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_node_status_allocatable_cpu_cores{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -3445,7 +3445,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_memory_bytes{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -3532,7 +3532,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_node_status_allocatable_memory_bytes{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{`{{node}}`}}",
+              "legendFormat": "{{node}}",
               "refId": "A"
             }
           ],
@@ -3587,7 +3587,6 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": true,
               "text": "skb-suy-adm01",
               "value": "skb-suy-adm01"
             },
@@ -3633,6 +3632,6 @@ data:
       "timezone": "",
       "title": "Cluster Overview (Total)",
       "uid": "taco-kubernetes-overview",
-      "version": 22
+      "version": 6
     }
 {{- end}}

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-pods.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-pods.yaml
@@ -29,12 +29,12 @@ data:
       "editable": true,
       "gnetId": 6781,
       "graphTooltip": 1,
-      "id": 20,
-      "iteration": 1598238908425,
+      "id": 78,
+      "iteration": 1608168459823,
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
@@ -444,7 +444,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_deployment_status_replicas_unavailable{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"})",
+              "expr": "sum(kube_deployment_status_replicas_unavailable{taco_cluster=\"$taco_cluster\"})",
               "instant": false,
               "refId": "A"
             }
@@ -637,7 +637,7 @@ data:
           "dashes": false,
           "datasource": "Prometheus",
           "decimals": 0,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -681,7 +681,7 @@ data:
               "expr": "sum(avg(kube_pod_status_phase{taco_cluster=~\"$taco_cluster\"}) by(pod, phase)) by(phase)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{ phase }}`}}",
+              "legendFormat": "{{ phase }}",
               "refId": "A",
               "step": 2
             }
@@ -734,7 +734,7 @@ data:
           "dashes": false,
           "datasource": "Prometheus",
           "decimals": 0,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
@@ -779,7 +779,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{`{{ pod }}`}}",
+              "legendFormat": "{{ pod }}",
               "refId": "A",
               "step": 2
             }
@@ -929,7 +929,7 @@ data:
           "dashes": false,
           "datasource": "Prometheus",
           "decimals": 0,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
@@ -973,7 +973,7 @@ data:
               "expr": "sum(avg(kube_pod_status_phase{taco_cluster=~\"$taco_cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}) by(namespace, pod, phase)) by(phase)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{ phase }}`}}",
+              "legendFormat": "{{ phase }}",
               "refId": "A",
               "step": 2
             }
@@ -1026,7 +1026,7 @@ data:
           "dashes": false,
           "datasource": "Prometheus",
           "decimals": 0,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -1071,7 +1071,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{`{{ pod }}`}}",
+              "legendFormat": "{{ pod }}",
               "refId": "A",
               "step": 2
             }
@@ -1151,7 +1151,7 @@ data:
           },
           "gridPos": {
             "h": 7,
-            "w": 4,
+            "w": 3,
             "x": 0,
             "y": 43
           },
@@ -1222,12 +1222,12 @@ data:
           "datasource": "Prometheus",
           "decimals": 0,
           "description": "",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 18,
-            "x": 4,
+            "w": 19,
+            "x": 3,
             "y": 43
           },
           "hiddenSeries": false,
@@ -1267,23 +1267,23 @@ data:
               "expr": "kube_deployment_status_replicas{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current: {{`{{ deployment }}`}}",
+              "legendFormat": "current: {{ deployment }}",
               "refId": "A",
               "step": 2
             },
             {
               "expr": "kube_deployment_status_replicas_available{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "available: {{`{{ deployment }}`}}",
+              "legendFormat": "available: {{ deployment }}",
               "refId": "C"
             },
             {
               "expr": "kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "unavailable: {{`{{ deployment }}`}}",
+              "legendFormat": "unavailable: {{ deployment }}",
               "refId": "B"
             },
             {
               "expr": "kube_deployment_spec_replicas{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "deseired: {{`{{ deployment }}`}}",
+              "legendFormat": "deseired: {{ deployment }}",
               "refId": "D"
             }
           ],
@@ -1418,7 +1418,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
@@ -1455,7 +1455,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_spec_replicas{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1590,7 +1590,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
@@ -1627,7 +1627,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1762,7 +1762,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
@@ -1799,7 +1799,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_available{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1971,7 +1971,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_unavailable{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -2079,7 +2079,7 @@ data:
             {
               "expr": "kube_deployment_spec_replicas{namespace=\"$namespace\", taco_cluster=\"$taco_cluster\"}",
               "instant": true,
-              "legendFormat": "{{`{{deployment}}`}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -2193,7 +2193,7 @@ data:
           "dashes": false,
           "datasource": "Prometheus",
           "decimals": 0,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
@@ -2235,20 +2235,20 @@ data:
           "targets": [
             {
               "expr": "kube_statefulset_status_replicas{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "desired: {{`{{ statefulset }}`}}",
+              "legendFormat": "desired: {{ statefulset }}",
               "refId": "B"
             },
             {
               "expr": "kube_statefulset_status_replicas_current{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current: {{`{{ statefulset }}`}}",
+              "legendFormat": "current: {{ statefulset }}",
               "refId": "A",
               "step": 2
             },
             {
               "expr": "kube_statefulset_status_replicas_ready{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "ready: {{`{{ statefulset }}`}}",
+              "legendFormat": "ready: {{ statefulset }}",
               "refId": "C"
             }
           ],
@@ -2372,7 +2372,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": " sum(rate(container_cpu_usage_seconds_total{taco_cluster=~\"$taco_cluster\", namespace=~\"$namespace\",pod=~\"$pod\",container=~\"$container\",container!=\"POD\",image!=\"\"}[2m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{taco_cluster=~\"$taco_cluster\", namespace=~\"$namespace\",image!=\"\"}[2m]))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
@@ -2486,7 +2486,7 @@ data:
           "description": "",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "grid": {},
           "gridPos": {
@@ -2499,9 +2499,9 @@ data:
           "id": 2,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
-            "max": false,
+            "max": true,
             "min": false,
             "rightSide": true,
             "show": true,
@@ -2530,7 +2530,7 @@ data:
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "Current: {{`{{ container }}`}}",
+              "legendFormat": "Current: {{ container }}",
               "refId": "A",
               "step": 2
             },
@@ -2539,7 +2539,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "Requested: {{`{{ container }}`}}",
+              "legendFormat": "Requested: {{ container }}",
               "refId": "B",
               "step": 2
             },
@@ -2548,7 +2548,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "legendFormat": "Limit: {{ container }}",
               "refId": "C",
               "step": 2
             }
@@ -2658,7 +2658,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{taco_cluster=~\"$taco_cluster\", namespace=~\"$namespace\", pod=~\"$pod\",container=~\"$container\", container!=\"POD\", container!=\"\",image!=\"\"})",
+              "expr": "sum(container_memory_working_set_bytes{taco_cluster=~\"$taco_cluster\", namespace=~\"$namespace\", image!=\"\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -2770,7 +2770,7 @@ data:
           "datasource": "Prometheus",
           "editable": false,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "grid": {},
           "gridPos": {
@@ -2784,13 +2784,13 @@ data:
           "legend": {
             "alignAsTable": true,
             "avg": false,
-            "current": false,
-            "max": false,
+            "current": true,
+            "max": true,
             "min": false,
             "rightSide": true,
             "show": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 2,
@@ -2814,7 +2814,7 @@ data:
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 1,
-              "legendFormat": "Current: {{`{{ container  }}`}}",
+              "legendFormat": "Current: {{ container  }}",
               "metric": "container_memory_usage_bytes",
               "refId": "A",
               "step": 10
@@ -2824,7 +2824,7 @@ data:
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 2,
-              "legendFormat": "Requested: {{`{{ container }}`}}",
+              "legendFormat": "Requested: {{ container }}",
               "metric": "kube_pod_container_resource_requests_memory_bytes",
               "refId": "B",
               "step": 20
@@ -2834,7 +2834,7 @@ data:
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 2,
-              "legendFormat": "Limit: {{`{{ container }}`}}",
+              "legendFormat": "Limit: {{ container }}",
               "metric": "kube_pod_container_resource_limits_memory_bytes",
               "refId": "C",
               "step": 20
@@ -3056,9 +3056,10 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
+          "decimals": 1,
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "grid": {},
           "gridPos": {
@@ -3073,7 +3074,7 @@ data:
             "alignAsTable": true,
             "avg": false,
             "current": true,
-            "max": false,
+            "max": true,
             "min": false,
             "rightSide": true,
             "show": true,
@@ -3101,7 +3102,7 @@ data:
               "expr": "rate (container_network_transmit_bytes_total{taco_cluster=~\"$taco_cluster\", namespace=\"$namespace\", pod=~\"$pod\",interface=~\"eth0|ens.*\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "TX : {{`{{ pod }}`}}",
+              "legendFormat": "TX : {{ pod }}",
               "refId": "A",
               "step": 2
             },
@@ -3109,7 +3110,7 @@ data:
               "expr": "rate (container_network_receive_bytes_total{taco_cluster=~\"$taco_cluster\", namespace=\"$namespace\", pod=~\"$pod\",interface=~\"eth0|ens.*\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "RX : {{`{{ pod }}`}}",
+              "legendFormat": "RX : {{ pod }}",
               "refId": "B",
               "step": 2
             }
@@ -3122,7 +3123,7 @@ data:
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -3161,10 +3162,7 @@ data:
       "refresh": "10s",
       "schemaVersion": 22,
       "style": "dark",
-      "tags": [
-        "kubernetes",
-        "pods"
-      ],
+      "tags": [],
       "templating": {
         "list": [
           {
@@ -3196,8 +3194,9 @@ data:
           {
             "allValue": ".*",
             "current": {
-              "text": "All",
-              "value": "All"
+              "selected": true,
+              "text": "argo",
+              "value": "argo"
             },
             "datasource": "Prometheus",
             "definition": "label_values(kube_pod_info{taco_cluster=~\"$taco_cluster\"}, namespace)",

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-node-networks.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-node-networks.yaml
@@ -28,8 +28,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 2,
-      "iteration": 1598238982315,
+      "id": 97,
+      "iteration": 1608168531443,
       "links": [],
       "panels": [
         {
@@ -43,6 +43,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
+          "decimals": 0,
           "fill": 2,
           "fillGradient": 0,
           "gridPos": {
@@ -55,13 +56,13 @@ data:
           "id": 22,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "total": false,
             "values": true
           },
@@ -119,7 +120,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive",
+              "legendFormat": "{{device}} - Receive",
               "refId": "O",
               "step": 4
             },
@@ -128,7 +129,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit",
+              "legendFormat": "{{device}} - Transmit",
               "refId": "P",
               "step": 4
             },
@@ -136,7 +137,7 @@ data:
               "expr": "irate(node_network_receive_packets_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive",
+              "legendFormat": "{{device}} - Receive",
               "refId": "A",
               "step": 4
             },
@@ -144,7 +145,7 @@ data:
               "expr": "irate(node_network_transmit_packets_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit",
+              "legendFormat": "{{device}} - Transmit",
               "refId": "B",
               "step": 4
             }
@@ -208,15 +209,15 @@ data:
           "id": 20,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "hideEmpty": false,
             "hideZero": false,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "sort": "current",
             "sortDesc": true,
             "total": false,
@@ -276,7 +277,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive errors",
+              "legendFormat": "{{device}} - Receive errors",
               "refId": "E",
               "step": 4
             },
@@ -285,7 +286,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit errors",
+              "legendFormat": "{{device}} - Transmit errors",
               "refId": "F",
               "step": 4
             },
@@ -294,7 +295,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive errors",
+              "legendFormat": "{{device}} - Receive errors",
               "refId": "A",
               "step": 4
             },
@@ -303,7 +304,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit errors",
+              "legendFormat": "{{device}} - Transmit errors",
               "refId": "B",
               "step": 4
             }
@@ -367,15 +368,15 @@ data:
           "id": 18,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "hideEmpty": false,
             "hideZero": false,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "sort": "current",
             "sortDesc": true,
             "total": false,
@@ -435,7 +436,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive drop",
+              "legendFormat": "{{device}} - Receive drop",
               "refId": "G",
               "step": 4
             },
@@ -444,7 +445,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit drop",
+              "legendFormat": "{{device}} - Transmit drop",
               "refId": "H",
               "step": 4
             },
@@ -452,7 +453,7 @@ data:
               "expr": "irate(node_network_receive_drop_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive drop",
+              "legendFormat": "{{device}} - Receive drop",
               "refId": "A",
               "step": 4
             },
@@ -460,7 +461,7 @@ data:
               "expr": "irate(node_network_transmit_drop_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit drop",
+              "legendFormat": "{{device}} - Transmit drop",
               "refId": "B",
               "step": 4
             }
@@ -524,15 +525,15 @@ data:
           "id": 16,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "hideEmpty": false,
             "hideZero": false,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "sort": "current",
             "sortDesc": true,
             "total": false,
@@ -592,7 +593,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive compressed",
+              "legendFormat": "{{device}} - Receive compressed",
               "refId": "C",
               "step": 4
             },
@@ -601,7 +602,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit compressed",
+              "legendFormat": "{{device}} - Transmit compressed",
               "refId": "D",
               "step": 4
             },
@@ -609,7 +610,7 @@ data:
               "expr": "irate(node_network_receive_compressed_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive compressed",
+              "legendFormat": "{{device}} - Receive compressed",
               "refId": "A",
               "step": 4
             },
@@ -617,7 +618,7 @@ data:
               "expr": "irate(node_network_transmit_compressed_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit compressed",
+              "legendFormat": "{{device}} - Transmit compressed",
               "refId": "B",
               "step": 4
             }
@@ -669,6 +670,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
+          "decimals": 1,
           "fill": 2,
           "fillGradient": 0,
           "gridPos": {
@@ -681,15 +683,15 @@ data:
           "id": 14,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "hideEmpty": false,
             "hideZero": false,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "sort": "current",
             "sortDesc": true,
             "total": false,
@@ -749,7 +751,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive multicast",
+              "legendFormat": "{{device}} - Receive multicast",
               "refId": "M",
               "step": 4
             },
@@ -757,21 +759,21 @@ data:
               "expr": "irate(node_network_transmit_multicast{instance=~\"$server\"}[5m])",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit multicast",
+              "legendFormat": "{{device}} - Transmit multicast",
               "refId": "A"
             },
             {
               "expr": "irate(node_network_receive_multicast_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive multicast",
+              "legendFormat": "{{device}} - Receive multicast",
               "refId": "B",
               "step": 4
             },
             {
               "expr": "irate(node_network_transmit_multicast_total{instance=~\"$server\"}[5m])",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit multicast",
+              "legendFormat": "{{device}} - Transmit multicast",
               "refId": "C"
             }
           ],
@@ -834,15 +836,15 @@ data:
           "id": 12,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "hideEmpty": false,
             "hideZero": false,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "sort": "current",
             "sortDesc": true,
             "total": false,
@@ -902,7 +904,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive fifo",
+              "legendFormat": "{{device}} - Receive fifo",
               "refId": "I",
               "step": 4
             },
@@ -911,7 +913,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit fifo",
+              "legendFormat": "{{device}} - Transmit fifo",
               "refId": "J",
               "step": 4
             },
@@ -919,7 +921,7 @@ data:
               "expr": "irate(node_network_receive_fifo_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive fifo",
+              "legendFormat": "{{device}} - Receive fifo",
               "refId": "A",
               "step": 4
             },
@@ -927,7 +929,7 @@ data:
               "expr": "irate(node_network_transmit_fifo_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Transmit fifo",
+              "legendFormat": "{{device}} - Transmit fifo",
               "refId": "B",
               "step": 4
             }
@@ -991,15 +993,15 @@ data:
           "id": 10,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "hideEmpty": false,
             "hideZero": false,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
-            "sideWidth": 300,
+            "sideWidth": null,
             "sort": "current",
             "sortDesc": true,
             "total": false,
@@ -1059,14 +1061,14 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive frame",
+              "legendFormat": "{{device}} - Receive frame",
               "refId": "K",
               "step": 4
             },
             {
               "expr": "irate(node_network_transmit_frame{instance=~\"$server\"}[5m])",
               "hide": true,
-              "legendFormat": "{{`{{device}}`}} - Transmit frame",
+              "legendFormat": "{{device}} - Transmit frame",
               "refId": "A"
             },
             {
@@ -1074,13 +1076,13 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{`{{device}}`}} - Receive frame",
+              "legendFormat": "{{device}} - Receive frame",
               "refId": "B",
               "step": 4
             },
             {
               "expr": "irate(node_network_transmit_frame_total{instance=~\"$server\"}[5m])",
-              "legendFormat": "{{`{{device}}`}} - Transmit frame",
+              "legendFormat": "{{device}} - Transmit frame",
               "refId": "C"
             }
           ],
@@ -1143,10 +1145,10 @@ data:
           "id": 4,
           "legend": {
             "alignAsTable": true,
-            "avg": true,
+            "avg": false,
             "current": true,
             "max": true,
-            "min": true,
+            "min": false,
             "rightSide": true,
             "show": true,
             "total": false,
@@ -1279,7 +1281,7 @@ data:
               "expr": "node_arp_entries{instance=~\"$server\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{`{{ device }}`}} - ARP entries",
+              "legendFormat": "{{ device }} - ARP entries",
               "refId": "A",
               "step": 4
             }
@@ -1337,7 +1339,7 @@ data:
               "text": "Prometheus",
               "value": "Prometheus"
             },
-            "hide": 0,
+            "hide": 2,
             "includeAll": false,
             "label": null,
             "multi": false,
@@ -1352,7 +1354,7 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "skb-suy-adm01",
               "value": "skb-suy-adm01"
             },
@@ -1378,18 +1380,68 @@ data:
           {
             "allValue": null,
             "current": {
+              "text": "suy-am01",
+              "value": "suy-am01"
+            },
+            "datasource": "$datasource",
+            "definition": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\", job=~\"$job\"}, nodename)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Hostname",
+            "multi": false,
+            "name": "hostname",
+            "options": [],
+            "query": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\", job=~\"$job\"}, nodename)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
               "text": "10.12.250.23:9100",
               "value": "10.12.250.23:9100"
             },
             "datasource": "$datasource",
-            "definition": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\"},  instance)",
-            "hide": 0,
+            "definition": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\", job=~\"$job\", nodename=~\"$hostname\"},instance)",
+            "hide": 1,
             "includeAll": false,
-            "label": "Host :",
+            "label": "",
             "multi": false,
             "name": "server",
             "options": [],
-            "query": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\"},  instance)",
+            "query": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\", job=~\"$job\", nodename=~\"$hostname\"},instance)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "prometheus-node-exporter",
+              "value": "prometheus-node-exporter"
+            },
+            "datasource": "$datasource",
+            "definition": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\"}, job)",
+            "hide": 2,
+            "includeAll": false,
+            "label": "job",
+            "multi": false,
+            "name": "job",
+            "options": [],
+            "query": "label_values(node_uname_info{taco_cluster=~\"$taco_cluster\"}, job)",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-nodestatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-nodestatus.yaml
@@ -29,8 +29,8 @@ data:
       "editable": true,
       "gnetId": 11074,
       "graphTooltip": 0,
-      "id": 21,
-      "iteration": 1598238939088,
+      "id": 79,
+      "iteration": 1608168479091,
       "links": [],
       "panels": [
         {
@@ -51,7 +51,26 @@ data:
                 "last"
               ],
               "defaults": {
-                "mappings": [],
+                "mappings": [
+                  {
+                    "from": "",
+                    "id": 1,
+                    "operator": "",
+                    "text": "Up",
+                    "to": "",
+                    "type": 1,
+                    "value": "1"
+                  },
+                  {
+                    "from": "",
+                    "id": 2,
+                    "operator": "",
+                    "text": "Down",
+                    "to": "",
+                    "type": 1,
+                    "value": "0"
+                  }
+                ],
                 "max": 1,
                 "min": 0,
                 "thresholds": {
@@ -72,8 +91,8 @@ data:
               "overrides": [],
               "values": false
             },
-            "graphMode": "none",
-            "justifyMode": "auto",
+            "graphMode": "area",
+            "justifyMode": "center",
             "orientation": "vertical"
           },
           "pluginVersion": "6.6.2",
@@ -84,9 +103,10 @@ data:
               "displayAliasType": "Warning / Critical",
               "displayType": "Regular",
               "displayValueWithAlias": "Never",
-              "expr": "sum(kube_node_status_condition{status=\"true\",condition=\"Ready\",taco_cluster=~\"$taco_cluster\"}) by (node)",
+              "expr": "sort (sum(kube_node_status_condition{status=\"true\",condition=\"Ready\",taco_cluster=~\"$taco_cluster\"}) by (node))",
               "instant": true,
-              "legendFormat": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{node}}",
               "refId": "A",
               "units": "none",
               "valueHandler": "Number Threshold"
@@ -108,7 +128,7 @@ data:
           },
           "id": 187,
           "panels": [],
-          "title": "Resource Overview (associated JOB)，Host：【$show_hostname】",
+          "title": "Resource Overview",
           "type": "row"
         },
         {
@@ -133,7 +153,7 @@ data:
           "styles": [
             {
               "alias": "Hostname",
-              "align": "auto",
+              "align": "center",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -153,7 +173,7 @@ data:
             },
             {
               "alias": "IP addr",
-              "align": "auto",
+              "align": "center",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -169,12 +189,12 @@ data:
               "mappingType": 1,
               "pattern": "instance",
               "thresholds": [],
-              "type": "number",
+              "type": "string",
               "unit": "short"
             },
             {
               "alias": "Memory",
-              "align": "auto",
+              "align": "center",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -192,7 +212,7 @@ data:
             },
             {
               "alias": "CPU Cores",
-              "align": "auto",
+              "align": "center",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -209,7 +229,7 @@ data:
             },
             {
               "alias": "Uptime",
-              "align": "auto",
+              "align": "center",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -226,7 +246,7 @@ data:
             },
             {
               "alias": "Partition used%*",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -246,7 +266,7 @@ data:
             },
             {
               "alias": "CPU used%",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -266,7 +286,7 @@ data:
             },
             {
               "alias": "Memory used%",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -286,7 +306,7 @@ data:
             },
             {
               "alias": "Disk read*",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -298,15 +318,15 @@ data:
               "mappingType": 1,
               "pattern": "Value #H",
               "thresholds": [
-                "10485760",
-                "20485760"
+                "52428800",
+                "83886080"
               ],
               "type": "number",
               "unit": "Bps"
             },
             {
               "alias": "Disk write*",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -318,15 +338,15 @@ data:
               "mappingType": 1,
               "pattern": "Value #I",
               "thresholds": [
-                "10485760",
-                "20485760"
+                "52428800",
+                "83886080"
               ],
               "type": "number",
               "unit": "Bps"
             },
             {
               "alias": "Download*",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -338,15 +358,15 @@ data:
               "mappingType": 1,
               "pattern": "Value #J",
               "thresholds": [
-                "30485760",
-                "104857600"
+                "524288000",
+                "1048576000"
               ],
               "type": "number",
               "unit": "bps"
             },
             {
               "alias": "Upload*",
-              "align": "auto",
+              "align": "center",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -358,15 +378,15 @@ data:
               "mappingType": 1,
               "pattern": "Value #K",
               "thresholds": [
-                "30485760",
-                "104857600"
+                "524288000",
+                "1048576000"
               ],
               "type": "number",
               "unit": "bps"
             },
             {
               "alias": "5m load",
-              "align": "auto",
+              "align": "center",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -399,7 +419,7 @@ data:
           ],
           "targets": [
             {
-              "expr": "node_uname_info{job=~\"$job\"} - 0",
+              "expr": "node_uname_info{job=~\"$job\",taco_cluster=~\"$taco_cluster\"} - 0",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -407,7 +427,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(time() - node_boot_time_seconds{job=~\"$job\"})by(instance)",
+              "expr": "sum(time() - node_boot_time_seconds{job=~\"$job\",taco_cluster=~\"$taco_cluster\"})by(instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -416,7 +436,7 @@ data:
               "refId": "D"
             },
             {
-              "expr": "node_memory_MemTotal_bytes{job=~\"$job\"} - 0",
+              "expr": "node_memory_MemTotal_bytes{job=~\"$job\",taco_cluster=~\"$taco_cluster\"} - 0",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -425,7 +445,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "count(node_cpu_seconds_total{job=~\"$job\",mode='system'}) by (instance)",
+              "expr": "count(node_cpu_seconds_total{job=~\"$job\",mode='system',taco_cluster=~\"$taco_cluster\"}) by (instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -434,7 +454,7 @@ data:
               "refId": "C"
             },
             {
-              "expr": "node_load5{job=~\"$job\"}",
+              "expr": "node_load5{job=~\"$job\",taco_cluster=~\"$taco_cluster\"}",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -442,7 +462,7 @@ data:
               "refId": "L"
             },
             {
-              "expr": "(1 - avg(irate(node_cpu_seconds_total{job=~\"$job\",mode=\"idle\"}[5m])) by (instance)) * 100",
+              "expr": "(1 - avg(irate(node_cpu_seconds_total{job=~\"$job\",mode=\"idle\",taco_cluster=~\"$taco_cluster\"}[5m])) by (instance)) * 100",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -451,7 +471,7 @@ data:
               "refId": "F"
             },
             {
-              "expr": "(1 - (node_memory_MemAvailable_bytes{job=~\"$job\"} / (node_memory_MemTotal_bytes{job=~\"$job\"})))* 100",
+              "expr": "(1 - (node_memory_MemAvailable_bytes{job=~\"$job\",taco_cluster=~\"$taco_cluster\"} / (node_memory_MemTotal_bytes{job=~\"$job\",taco_cluster=~\"$taco_cluster\"})))* 100",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -460,7 +480,7 @@ data:
               "refId": "G"
             },
             {
-              "expr": "max((node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\"}) *100/(node_filesystem_avail_bytes {job=~\"$job\",fstype=~\"ext.?|xfs\"}+(node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\"})))by(instance)",
+              "expr": "max((node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=~\"$taco_cluster\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=~\"$taco_cluster\"}) *100/(node_filesystem_avail_bytes {job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=~\"$taco_cluster\"}+(node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=~\"$taco_cluster\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=~\"$taco_cluster\"})))by(instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -469,7 +489,7 @@ data:
               "refId": "E"
             },
             {
-              "expr": "max(irate(node_disk_read_bytes_total{job=~\"$job\"}[5m])) by (instance)",
+              "expr": "max(irate(node_disk_read_bytes_total{job=~\"$job\",taco_cluster=~\"$taco_cluster\"}[5m])) by (instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -478,7 +498,7 @@ data:
               "refId": "H"
             },
             {
-              "expr": "max(irate(node_disk_written_bytes_total{job=~\"$job\"}[5m])) by (instance)",
+              "expr": "max(irate(node_disk_written_bytes_total{job=~\"$job\",taco_cluster=~\"$taco_cluster\"}[5m])) by (instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -487,7 +507,7 @@ data:
               "refId": "I"
             },
             {
-              "expr": "max(irate(node_network_receive_bytes_total{job=~\"$job\"}[5m])*8) by (instance)",
+              "expr": "max(irate(node_network_receive_bytes_total{job=~\"$job\",taco_cluster=~\"$taco_cluster\"}[5m])*8) by (instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -496,7 +516,7 @@ data:
               "refId": "J"
             },
             {
-              "expr": "max(irate(node_network_transmit_bytes_total{job=~\"$job\"}[5m])*8) by (instance)",
+              "expr": "max(irate(node_network_transmit_bytes_total{job=~\"$job\",taco_cluster=~\"$taco_cluster\"}[5m])*8) by (instance)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -556,7 +576,7 @@ data:
               "expr": "(1 - avg(irate(node_cpu_seconds_total{job=~\"$job\",mode=\"idle\", taco_cluster=\"$taco_cluster\"}[5m])) by (instance)) * 100 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
               "format": "time_series",
               "intervalFactor": 3,
-              "legendFormat": "{{`{{nodename}}`}}",
+              "legendFormat": "{{nodename}}",
               "refId": "A"
             }
           ],
@@ -567,7 +587,7 @@ data:
           "title": "CPU Usage",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -644,7 +664,7 @@ data:
           "targets": [
             {
               "expr": "(1 - (node_memory_MemAvailable_bytes{job=~\"$job\", taco_cluster=\"$taco_cluster\"} / (node_memory_MemTotal_bytes{job=~\"$job\", taco_cluster=\"$taco_cluster\"})))* 100 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{`{{nodename}}`}}",
+              "legendFormat": "{{nodename}}",
               "refId": "A"
             }
           ],
@@ -655,7 +675,7 @@ data:
           "title": "Mem Usage",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -695,7 +715,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
@@ -732,7 +752,7 @@ data:
           "targets": [
             {
               "expr": "max((node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}) *100/(node_filesystem_avail_bytes {job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}+(node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"})))by(instance) + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{`{{nodename}}`}}",
+              "legendFormat": "{{nodename}}",
               "refId": "A"
             }
           ],
@@ -743,7 +763,7 @@ data:
           "title": "Disk Usage",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -820,7 +840,7 @@ data:
           "targets": [
             {
               "expr": "sum by (instance) (irate(node_network_transmit_bytes_total{device=~\"ens\\\\w*\", taco_cluster=~\"$taco_cluster\"}[5m])) * 8 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{`{{nodename}}`}}",
+              "legendFormat": "{{nodename}}",
               "refId": "A"
             }
           ],
@@ -908,7 +928,7 @@ data:
           "targets": [
             {
               "expr": "sum by (instance) (irate(node_network_receive_bytes_total{device=~\"ens\\\\w*\", taco_cluster=~\"$taco_cluster\"}[5m])) * 8 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{`{{nodename}}`}}",
+              "legendFormat": "{{nodename}}",
               "refId": "A"
             }
           ],
@@ -1993,7 +2013,7 @@ data:
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{instance}}`}}",
+              "legendFormat": "{{instance}}",
               "refId": "A",
               "step": 20
             }
@@ -2645,7 +2665,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{mountpoint}}`}}",
+              "legendFormat": "{{mountpoint}}",
               "refId": "A"
             }
           ],
@@ -2759,7 +2779,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_Read bytes",
+              "legendFormat": "{{device}}_Read bytes",
               "refId": "A",
               "step": 10
             },
@@ -2769,7 +2789,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_Written bytes",
+              "legendFormat": "{{device}}_Written bytes",
               "refId": "B",
               "step": 10
             }
@@ -2885,7 +2905,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_Read time",
+              "legendFormat": "{{device}}_Read time",
               "refId": "B"
             },
             {
@@ -2895,7 +2915,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_Write time",
+              "legendFormat": "{{device}}_Write time",
               "refId": "C"
             }
           ],
@@ -3008,7 +3028,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_Reads completed",
+              "legendFormat": "{{device}}_Reads completed",
               "refId": "A",
               "step": 10
             },
@@ -3018,7 +3038,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_Writes completed",
+              "legendFormat": "{{device}}_Writes completed",
               "refId": "B",
               "step": 10
             }
@@ -3140,7 +3160,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{`{{device}}`}}_ IO time",
+              "legendFormat": "{{device}}_ IO time",
               "refId": "C"
             }
           ],
@@ -3687,6 +3707,489 @@ data:
           "dashes": false,
           "datasource": "Prometheus",
           "decimals": 2,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 86
+          },
+          "height": "300",
+          "hiddenSeries": false,
+          "id": 213,
+          "interval": "",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "{{ pod }}",
+              "fill": 1,
+              "fillGradient": 1
+            },
+            {
+              "alias": "suy-aw01",
+              "color": "#3274D9",
+              "lines": true
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sort_desc (sum by (pod) (rate(container_cpu_usage_seconds_total{taco_cluster=~\"$taco_cluster\", node=\"$show_hostname\", image!=\"\"}[2m])))",
+              "legendFormat": "{{ pod }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage of All Pods in $show_hostname (Rate of CPU Time)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "192.168.200.241:9100_TCP_alloc": "semi-dark-blue",
+            "TCP": "#6ED0E0",
+            "TCP_alloc": "blue"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 2,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 97
+          },
+          "height": "300",
+          "hiddenSeries": false,
+          "id": 214,
+          "interval": "",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg by(pod) (container_memory_working_set_bytes{taco_cluster=~\"$taco_cluster\", node=\"$show_hostname\",container!=\"POD\",container!=\"\",image!=\"\"})",
+              "legendFormat": "{{ pod }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage of All Pods in $show_hostname (2min avg)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "decbytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "192.168.200.241:9100_TCP_alloc": "semi-dark-blue",
+            "TCP": "#6ED0E0",
+            "TCP_alloc": "blue"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 2,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 108
+          },
+          "height": "300",
+          "hiddenSeries": false,
+          "id": 158,
+          "interval": "",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*Sockets_used/",
+              "color": "#E02F44",
+              "lines": false,
+              "pointradius": 1,
+              "points": true,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (pod) (rate(container_network_receive_bytes_total{taco_cluster=~\"$taco_cluster\", interface=~\"cali.*\", node=\"$show_hostname\"}[1m])) * 8",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}}",
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "RX of All Pods in $show_hostname (from calico device)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "Total_Sockets_used",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "192.168.200.241:9100_TCP_alloc": "semi-dark-blue",
+            "TCP": "#6ED0E0",
+            "TCP_alloc": "blue"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 2,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 118
+          },
+          "height": "300",
+          "hiddenSeries": false,
+          "id": 212,
+          "interval": "",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*Sockets_used/",
+              "color": "#E02F44",
+              "lines": false,
+              "pointradius": 1,
+              "points": true,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{taco_cluster=~\"$taco_cluster\", interface=~\"cali.*\", node=\"$show_hostname\"}[1m])) * 8",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}}",
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TX of All Pods in $show_hostname (from calico device)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "Total_Sockets_used",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "192.168.200.241:9100_TCP_alloc": "semi-dark-blue",
+            "TCP": "#6ED0E0",
+            "TCP_alloc": "blue"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 2,
           "description": "Sockets_used - Sockets currently in use\n\nCurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE- WAIT\n\nTCP_alloc - Allocated sockets\n\nTCP_tw - Sockets wating close\n\nUDP_inuse - Udp sockets currently in use\n\nRetransSegs - TCP retransmission packets\n\nOutSegs - Number of packets sent by TCP\n\nInSegs - Number of packets received by TCP",
           "fieldConfig": {
             "defaults": {
@@ -3700,11 +4203,11 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 86
+            "y": 129
           },
           "height": "300",
           "hiddenSeries": false,
-          "id": 158,
+          "id": 211,
           "interval": "",
           "legend": {
             "alignAsTable": true,
@@ -3790,14 +4293,14 @@ data:
               "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=~'$node'}[5m])",
               "hide": true,
               "interval": "",
-              "legendFormat": "{{`{{instance}}`}}_Tcp_PassiveOpens",
+              "legendFormat": "{{instance}}_Tcp_PassiveOpens",
               "refId": "G"
             },
             {
               "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=~'$node'}[5m])",
               "hide": true,
               "interval": "",
-              "legendFormat": "{{`{{instance}}`}}_Tcp_ActiveOpens",
+              "legendFormat": "{{instance}}_Tcp_ActiveOpens",
               "refId": "F"
             },
             {
@@ -3879,7 +4382,7 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "skb-suy-adm01",
               "value": "skb-suy-adm01"
             },
@@ -3987,13 +4490,14 @@ data:
             "allFormat": "glob",
             "allValue": ".*",
             "current": {
-              "selected": false,
               "text": "All",
-              "value": "$__all"
+              "value": [
+                "$__all"
+              ]
             },
             "datasource": "Prometheus",
             "definition": "label_values(node_network_info{taco_cluster=~\"$taco_cluster\", device!~'tap.*|veth.*|br.*|docker.*|virbr.*|lo.*|cni.*'},device)",
-            "hide": 0,
+            "hide": 2,
             "includeAll": true,
             "index": -1,
             "label": "NIC",
@@ -4067,7 +4571,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-12h",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-tridentstatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-tridentstatus.yaml
@@ -28,17 +28,752 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 27,
+      "id": 90,
+      "iteration": 1608168611330,
       "links": [],
       "panels": [
+        {
+          "collapsed": true,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 39,
+          "panels": [],
+          "title": "Trident POD Status",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 12,
+            "w": 11,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 25,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum (rate(container_cpu_usage_seconds_total{taco_cluster=~\"skb-suy-adm.*\",container=~\"trident.*\",namespace=~\"trident\",pod=~\"trident.*\"}[1m])) by (pod)\r",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}}",
+              "refId": "A",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage ($taco_cluster)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "editable": false,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 12,
+            "w": 11,
+            "x": 11,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 27,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum (container_memory_working_set_bytes{taco_cluster=\"$taco_cluster\", container=~\"trident.*\",namespace=~\"trident\",pod=~\"trident.*\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{pod}} ",
+              "metric": "container_memory_usage_bytes",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage ($taco_cluster)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "id": 35,
+          "panels": [],
+          "title": "PV Status",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "gridPos": {
+            "h": 12,
+            "w": 22,
+            "x": 0,
+            "y": 14
+          },
+          "id": 37,
+          "links": [],
+          "options": {
+            "displayMode": "gradient",
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "decimals": 1,
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 75
+                    },
+                    {
+                      "color": "red",
+                      "value": 85
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showUnfilled": true
+          },
+          "pluginVersion": "6.6.2",
+          "targets": [
+            {
+              "expr": "(kubelet_volume_stats_used_bytes {taco_cluster=\"$taco_cluster\"} / kubelet_volume_stats_capacity_bytes {taco_cluster=\"$taco_cluster\"}) * 100 ",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$taco_cluster : PV Usage (%) ",
+          "type": "bargauge"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 33,
+          "panels": [],
+          "title": "NetApp Storage Status",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 22,
+            "x": 0,
+            "y": 27
+          },
+          "hiddenSeries": false,
+          "id": 23,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pluginVersion": "6.6.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "trident_core_backend_info{backend_type=\"ontap-nas\"}",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{backend_name}}:{{taco_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "NetApp Backend Status",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
         {
           "cacheTimeout": null,
           "datasource": null,
           "gridPos": {
+            "h": 9,
+            "w": 10,
+            "x": 0,
+            "y": 34
+          },
+          "id": 22,
+          "links": [],
+          "options": {
+            "displayMode": "basic",
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showUnfilled": true
+          },
+          "pluginVersion": "6.6.2",
+          "targets": [
+            {
+              "aggregation": "Last",
+              "decimals": 2,
+              "displayAliasType": "Warning / Critical",
+              "displayType": "Regular",
+              "displayValueWithAlias": "Never",
+              "expr": "sum by (operation) (trident_operation_duration_milliseconds_sum{success=\"true\"}) / sum by (operation) (trident_operation_duration_milliseconds_count{success=\"true\"})",
+              "instant": false,
+              "legendFormat": "{{ operation }}",
+              "refId": "A",
+              "units": "none",
+              "valueHandler": "Number Threshold"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Average duration in ms of operations performed by Trident",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "Prometheus",
+          "gridPos": {
+            "h": 9,
+            "w": 7,
+            "x": 10,
+            "y": 34
+          },
+          "id": 12,
+          "interval": "",
+          "options": {
+            "colorMode": "value",
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [],
+              "values": true
+            },
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto"
+          },
+          "pluginVersion": "6.6.2",
+          "targets": [
+            {
+              "expr": "sort (trident_core_volume_count{taco_cluster=~\"skb.*\"} + on(backend_uuid) group_left(backend_name) trident_backend_info {taco_cluster=~\"skb.*\"})",
+              "instant": true,
+              "legendFormat": "{{ taco_cluster }}::{{ backend_name }}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "# Volumes currently managed",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "gridPos": {
+            "h": 9,
+            "w": 5,
+            "x": 17,
+            "y": 34
+          },
+          "id": 14,
+          "options": {
+            "colorMode": "value",
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "decimals": 2,
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-blue",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              "overrides": [],
+              "values": true
+            },
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto"
+          },
+          "pluginVersion": "6.6.2",
+          "targets": [
+            {
+              "expr": "trident_core_volume_total_bytes / 1024 / 1024 / 1024",
+              "instant": true,
+              "legendFormat": "{{taco_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Capacity currently managed (GB)",
+          "type": "stat"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
             "h": 8,
+            "w": 11,
+            "x": 0,
+            "y": 43
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pluginVersion": "6.6.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "trident_core_volume_count_by_backend",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{backend}}:{{taco_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of volumes by Cluster",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 0,
+          "fillGradient": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 11,
+            "x": 11,
+            "y": 43
+          },
+          "hiddenSeries": false,
+          "id": 18,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "trident_core_volume_total_bytes_by_backend / 1024 / 1024 / 1024",
+              "legendFormat": "{{backend}}:{{taco_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total Capacity by Cluster",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "GB",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": null,
+          "description": "",
+          "gridPos": {
+            "h": 6,
             "w": 7,
             "x": 0,
-            "y": 0
+            "y": 51
           },
           "id": 20,
           "links": [],
@@ -88,24 +823,25 @@ data:
           "pluginVersion": "6.6.2",
           "targets": [
             {
-              "expr": "100-(sum (trident_rest_ops_seconds_total_count{status_code=~\"2..\"} OR on() vector(0)) / sum (trident_rest_ops_seconds_total_count)) * 100",
+              "expr": "100-(sum (trident_rest_ops_seconds_total_count{taco_cluster=~\"$taco_cluster\", status_code=~\"2..\"} OR on() vector(0)) / sum (trident_rest_ops_seconds_total_count{taco_cluster=~\"$taco_cluster\"})) * 100",
               "instant": false,
               "refId": "A"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Percentage of Failed HTTP responses from Trident",
+          "title": "Percentage of Failed HTTP responses ($taco_cluster)",
           "type": "stat"
         },
         {
           "cacheTimeout": null,
           "datasource": null,
+          "description": "",
           "gridPos": {
-            "h": 8,
+            "h": 6,
             "w": 15,
             "x": 7,
-            "y": 0
+            "y": 51
           },
           "id": 21,
           "links": [],
@@ -151,8 +887,9 @@ data:
               "displayAliasType": "Warning / Critical",
               "displayType": "Regular",
               "displayValueWithAlias": "Never",
-              "expr": "(sum (trident_rest_ops_seconds_total_count) by (status_code)  / scalar (sum (trident_rest_ops_seconds_total_count))) * 100",
+              "expr": "(sum (trident_rest_ops_seconds_total_count{taco_cluster=\"$taco_cluster\"}) by (status_code)  / scalar (sum (trident_rest_ops_seconds_total_count{taco_cluster=\"$taco_cluster\"}))) * 100",
               "instant": false,
+              "legendFormat": "{{ status_code }}",
               "refId": "A",
               "units": "none",
               "valueHandler": "Number Threshold"
@@ -160,345 +897,8 @@ data:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Percentage of HTTP responses from Trident",
+          "title": "Percentage of HTTP responses ($taco_cluster)",
           "type": "gauge"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": null,
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 8
-          },
-          "id": 22,
-          "links": [],
-          "options": {
-            "displayMode": "basic",
-            "fieldOptions": {
-              "calcs": [
-                "mean"
-              ],
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "overrides": [],
-              "values": false
-            },
-            "orientation": "horizontal",
-            "showUnfilled": true
-          },
-          "pluginVersion": "6.6.2",
-          "targets": [
-            {
-              "aggregation": "Last",
-              "decimals": 2,
-              "displayAliasType": "Warning / Critical",
-              "displayType": "Regular",
-              "displayValueWithAlias": "Never",
-              "expr": "sum by (operation) (trident_operation_duration_milliseconds_sum{success=\"true\"}) / sum by (operation) (trident_operation_duration_milliseconds_count{success=\"true\"})",
-              "instant": false,
-              "refId": "A",
-              "units": "none",
-              "valueHandler": "Number Threshold"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Average duration in ms of operations performed by Trident",
-          "type": "bargauge"
-        },
-        {
-          "datasource": "Prometheus",
-          "gridPos": {
-            "h": 9,
-            "w": 5,
-            "x": 12,
-            "y": 8
-          },
-          "id": 12,
-          "options": {
-            "colorMode": "value",
-            "fieldOptions": {
-              "calcs": [
-                "mean"
-              ],
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "dark-blue",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": [],
-              "values": true
-            },
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto"
-          },
-          "pluginVersion": "6.6.2",
-          "targets": [
-            {
-              "expr": "sort (trident_core_volume_count)",
-              "instant": true,
-              "legendFormat": "{{`{{taco_cluster}}`}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "# Volumes currently managed",
-          "type": "stat"
-        },
-        {
-          "datasource": "Prometheus",
-          "gridPos": {
-            "h": 9,
-            "w": 5,
-            "x": 17,
-            "y": 8
-          },
-          "id": 14,
-          "options": {
-            "colorMode": "value",
-            "fieldOptions": {
-              "calcs": [
-                "mean"
-              ],
-              "defaults": {
-                "decimals": 2,
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "dark-blue",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "overrides": [],
-              "values": true
-            },
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto"
-          },
-          "pluginVersion": "6.6.2",
-          "targets": [
-            {
-              "expr": "trident_core_volume_total_bytes / 1024 / 1024 / 1024",
-              "instant": true,
-              "legendFormat": "{{`{{taco_cluster}}`}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Capacity currently managed (GB)",
-          "type": "stat"
-        },
-        {
-          "aliasColors": {},
-          "bars": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "Prometheus",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
-            "y": 17
-          },
-          "hiddenSeries": false,
-          "id": 16,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pluginVersion": "6.6.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "trident_core_volume_count_by_backend",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{`{{backend}}`}}:{{`{{taco_cluster}}`}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Number of volumes by Trident driver type",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "Prometheus",
-          "fill": 1,
-          "fillGradient": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 11,
-            "y": 17
-          },
-          "hiddenSeries": false,
-          "id": 18,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "trident_core_volume_total_bytes_by_backend / 1024 / 1024 / 1024",
-              "legendFormat": "{{`{{backend}}`}}:{{`{{taco_cluster}}`}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Total Capacity by Trident driver type",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": "GB",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
         }
       ],
       "refresh": "30s",
@@ -506,7 +906,34 @@ data:
       "style": "dark",
       "tags": [],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "skb-suy-adm01",
+              "value": "skb-suy-adm01"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(up, taco_cluster)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "taco_cluster",
+            "multi": false,
+            "name": "taco_cluster",
+            "options": [],
+            "query": "label_values(up, taco_cluster)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
       },
       "time": {
         "from": "now-30m",


### PR DESCRIPTION
Update following dashboards.
 - ETCD cluster status
 - Multi-Kubernetes cluster overview
 - Kubernetes cluster status
 - Kubernetes POD status
 - Node status
 - Node network status
 - NetApp Trident status

Add a new dashboard.
 - F5 Big IP controller status
