### PR TITLE
add 'eck-resource' helm chart.

### DIFF
--- a/eck-resource/Chart.yaml
+++ b/eck-resource/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Deploy resources of eck operator
+name: eck-resource
+version: 1.0.0

--- a/eck-resource/templates/_helpers.tpl
+++ b/eck-resource/templates/_helpers.tpl
@@ -1,10 +1,10 @@
 {{/* vim: set filetype=mustache: */}}
-{{- define "elasticsearch-operator.name" -}}
+{{- define "eck-resource.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" -}}
 {{- end }}
 
 {{/* Generate basic labels */}}
-{{- define "elasticsearch-operator.labels" }}
+{{- define "eck-resource.labels" }}
 release: {{ .Release.Name | quote }}
 heritage: {{ .Release.Service | quote }}
 {{- end }}

--- a/eck-resource/templates/_helpers.tpl
+++ b/eck-resource/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/* vim: set filetype=mustache: */}}
+{{- define "elasticsearch-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" -}}
+{{- end }}
+
+{{/* Generate basic labels */}}
+{{- define "elasticsearch-operator.labels" }}
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service | quote }}
+{{- end }}

--- a/eck-resource/templates/elasticsearch.yaml
+++ b/eck-resource/templates/elasticsearch.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.elasticsearch.enabled }}
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: {{ template "elasticsearch-operator.name" . }}-elasticsearch
+spec:
+  version: {{ .Values.elasticsearch.image.tag }}
+  image: {{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}
+{{- if not .Values.elasticsearch.podDisruptionBudget.enabled }}
+  podDisruptionBudget: {}
+{{- end }}
+  nodeSets:
+{{- range $name, $node := .Values.elasticsearch.nodeSets}}
+  {{- if $node.enabled}}
+  - name: {{ $name}}
+    count: {{ $node.count }}
+    config:
+  {{- toYaml $node.config | nindent 6 }}
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: {{ $node.limitMem | quote }}
+              cpu: {{ $node.limitCpu }}   
+          env:
+          - name: ES_JAVA_OPTS
+            value: {{ $node.javaOpts | quote }}
+  {{- if $node.nodeSelector }}
+        nodeSelector:
+    {{- toYaml $node.nodeSelector | nindent 10 }}
+  {{- end }}
+  {{- if $node.pvc }}
+    volumeClaimTemplates:
+      - metadata:
+          name: elasticsearch-data
+        spec:
+          accessModes: [{{ $node.pvc.accessModes }}]
+          resources:
+            requests:
+              storage: {{ $node.pvc.size }}
+          storageClassName: {{ $node.pvc.storageClassName }}
+  {{- end }}
+  {{- end}}  
+{{- end}}  
+{{- if .Values.elasticsearch.http }}
+{{ toYaml .Values.elasticsearch.http | indent 2 }}
+{{- end }}
+{{- end }}

--- a/eck-resource/templates/elasticsearch.yaml
+++ b/eck-resource/templates/elasticsearch.yaml
@@ -2,7 +2,7 @@
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
-  name: {{ template "elasticsearch-operator.name" . }}-elasticsearch
+  name: {{ template "eck-resource.name" . }}-elasticsearch
 spec:
   version: {{ .Values.elasticsearch.image.tag }}
   image: {{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}

--- a/eck-resource/templates/kibana.yaml
+++ b/eck-resource/templates/kibana.yaml
@@ -2,7 +2,7 @@
 apiVersion: kibana.k8s.elastic.co/v1beta1
 kind: Kibana
 metadata:
-  name: {{ template "elasticsearch-operator.name" . }}-kibana
+  name: {{ template "eck-resource.name" . }}-kibana
 spec:
   version: {{ default "7.4.2" .Values.kibana.image.tag }}
   image: "{{ .Values.kibana.image.repository }}:{{ .Values.kibana.image.tag }}"
@@ -12,7 +12,7 @@ spec:
 {{- end }}
   count: 1
   elasticsearchRef:
-    name: {{ template "elasticsearch-operator.name" . }}-elasticsearch
+    name: {{ template "eck-resource.name" . }}-elasticsearch
 {{- if .Values.kibana.http }}
   http:
 {{ toYaml .Values.kibana.http | indent 4 }}

--- a/eck-resource/templates/kibana.yaml
+++ b/eck-resource/templates/kibana.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.kibana.enabled }}
+apiVersion: kibana.k8s.elastic.co/v1beta1
+kind: Kibana
+metadata:
+  name: {{ template "elasticsearch-operator.name" . }}-kibana
+spec:
+  version: {{ default "7.4.2" .Values.kibana.image.tag }}
+  image: "{{ .Values.kibana.image.repository }}:{{ .Values.kibana.image.tag }}"
+{{- if .Values.kibana.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.kibana.nodeSelector | indent 4 }}
+{{- end }}
+  count: 1
+  elasticsearchRef:
+    name: {{ template "elasticsearch-operator.name" . }}-elasticsearch
+{{- if .Values.kibana.http }}
+  http:
+{{ toYaml .Values.kibana.http | indent 4 }}
+{{- end }}
+  podTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - name: kibana
+        resources:
+          limits:
+            memory: {{ .Values.kibana.limitMem | quote }}
+            cpu: {{ .Values.kibana.limitCpu }}             
+{{- if .Values.kibana.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.kibana.nodeSelector | indent 8 }}
+{{- end }}
+{{- end }}

--- a/eck-resource/templates/secret-elasticsearch.yaml
+++ b/eck-resource/templates/secret-elasticsearch.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.elasticsearch.enabled .Values.elasticsearch.adminPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "elasticsearch-operator.name" . }}-elasticsearch-es-elastic-user
+  labels:
+    common.k8s.elastic.co/type: elasticsearch
+    elasticsearch.k8s.elastic.co/cluster-name: {{ template "elasticsearch-operator.name" . }}-elasticsearch
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  elastic: {{ .Values.elasticsearch.adminPassword | b64enc }}
+{{- end }}

--- a/eck-resource/templates/secret-elasticsearch.yaml
+++ b/eck-resource/templates/secret-elasticsearch.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "elasticsearch-operator.name" . }}-elasticsearch-es-elastic-user
+  name: {{ template "eck-resource.name" . }}-elasticsearch-es-elastic-user
   labels:
     common.k8s.elastic.co/type: elasticsearch
-    elasticsearch.k8s.elastic.co/cluster-name: {{ template "elasticsearch-operator.name" . }}-elasticsearch
+    elasticsearch.k8s.elastic.co/cluster-name: {{ template "eck-resource.name" . }}-elasticsearch
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/eck-resource/values.yaml
+++ b/eck-resource/values.yaml
@@ -54,7 +54,7 @@ elasticsearch:
       javaOpts: "-Xms256m -Xmx256m"
       ## Resource Max
       limitCpu: 1
-      limitMem: 0.5Gi  
+      limitMem: 1Gi  
       ## Storage definition for Elasticsearch instance.
       ## Must be set
       ##

--- a/eck-resource/values.yaml
+++ b/eck-resource/values.yaml
@@ -1,0 +1,152 @@
+## override Chart Name
+nameOverride: eck
+
+elasticsearch:
+  enabled: true
+
+  # admin account's password is generated randomly by default.
+  # if you want to set the password of admin account, set below value. 
+  adminPassword: password
+
+  image:
+    repository: docker.elastic.co/elasticsearch/elasticsearch
+    tag: 7.5.1
+
+  ## empty {} means podDisruptionBudget disabled
+  podDisruptionBudget:
+    enabled: false
+
+  ## http setting for Elasticsearch
+  http:
+    ports:
+    - name: elasticsearch
+      targetPort: 9200
+      port: 9200
+  #   service:
+  #     spec:
+  #       # expose this cluster Service with a LoadBalancer
+  #       type: LoadBalancer
+  #   tls:
+  #     selfSignedCertificate:
+  #       # add a list of SANs into the self-signed HTTP certificate
+  #       subjectAltNames:
+  #       - ip: 192.168.1.2
+  #       - ip: 192.168.1.3
+  #       - dns: elasticsearch-sample.example.com
+  #     certificate:
+  #       # provide your own certificate
+  #       secretName: my-cert
+
+  nodeSets:
+    master:
+      enabled: true
+      # nodeSelector:
+      #   taco-lma: enabled
+      ## Elasticsearch instance count 
+      count: 3
+      ## Elasticsearch Config
+      config:
+        node.master: true
+        node.data: false
+        node.ingest: false
+        node.store.allow_mmap: false
+      ## JVM Memory config
+      javaOpts: "-Xms256m -Xmx256m"
+      ## Resource Max
+      limitCpu: 1
+      limitMem: 0.5Gi  
+      ## Storage definition for Elasticsearch instance.
+      ## Must be set
+      ##
+      pvc:
+        accessModes: "ReadWriteOnce"
+        storageClassName: rbd
+        size: 1Gi
+    hotdata: 
+      enabled: true
+      # nodeSelector:
+      #   taco-lma: enabled
+      ## Elasticsearch instance count 
+      count: 3
+      ## Elasticsearch Config
+      config:
+        node.data: true
+        node.ingest: true
+        node.master: false
+        node.store.allow_mmap: false
+        node.attr.hotwarm: hot
+      javaOpts: "-Xms2g -Xmx2g"
+      limitCpu: 1
+      limitMem: 4Gi
+      pvc:
+        accessModes: "ReadWriteOnce"
+        storageClassName: rbd
+        size: 5Gi
+    warmdata: 
+      enabled: false
+      # nodeSelector:
+      #   taco-lma: enabled
+      ## Elasticsearch instance count 
+      count: 2
+      ## Elasticsearch Config
+      config:
+        node.data: true
+        node.ingest: true
+        node.master: false
+        node.store.allow_mmap: false
+        node.attr.hotwarm: warm 
+      javaOpts: "-Xms256m -Xmx256m"
+      limitCpu: 1
+      limitMem: 0.5Gi
+      pvc:
+        accessModes: "ReadWriteOnce"
+        storageClassName: rbd
+        size: 10Gi
+    client: 
+      enabled: true
+      # nodeSelector:
+      #   taco-lma: enabled
+      ## Elasticsearch instance count 
+      count: 1
+      ## Elasticsearch Config
+      config:
+        node.data: false
+        node.ingest: false
+        node.master: false
+        node.store.allow_mmap: false 
+      javaOpts: "-Xms1g -Xmx1g"
+      limitCpu: 1
+      limitMem: 2Gi
+      pvc:
+        accessModes: "ReadWriteOnce"
+        storageClassName: rbd
+        size: 10Gi
+kibana:
+  enabled: true
+  image:
+    repository: docker.elastic.co/kibana/kibana
+    tag: 7.5.1
+
+  limitCpu: 1
+  limitMem: 2Gi
+  ## container resources
+  # resources:
+  #   limits:
+  #     cpu:
+  #     memory:
+  ## http setting for Kibana instance
+  http:
+    service:
+      spec:
+        type: NodePort
+        ports:
+        - name: kibana-dashboard-kb-http
+          nodePort: 30001
+          targetPort: 5601
+          port: 5601
+  # nodeSelector:
+  #   taco-lma: enabled
+  #  tls:
+  #    certificate: {}
+  #    selfSignedCertificate:
+  #      disabled: true


### PR DESCRIPTION
### Issue
https://github.com/openinfradev/decapod-base-yaml/issues/23

### Description
* elastic 공식 차트인 eck-operator를 사용하기로 함.
* eck-operator는 operator를 설치해주지만 custom resource(elasticsearch, kibana 등)을 만들진 않음
* 따라서 custom resource를 만들어주는 eck-resource라는 차트를 별도로 생성함