### PR TITLE
Fix bug in lma-addons chart

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project 
 name: lma-addons
-version: 1.0.6
+version: 1.0.7

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-etcdcluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-etcdcluster.yaml
@@ -331,7 +331,7 @@ data:
               "expr": "etcd_server_is_leader{taco_cluster=~\"$taco_cluster\"}",
               "format": "table",
               "instant": true,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{`{{instance}}`}}",
               "refId": "A"
             }
           ],
@@ -391,7 +391,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} DB Size",
+              "legendFormat": "{{`{{instance}}`}} DB Size",
               "metric": "",
               "refId": "A",
               "step": 4
@@ -692,7 +692,7 @@ data:
             {
               "expr": "rate(etcd_network_client_grpc_received_bytes_total{taco_cluster=\"$taco_cluster\"}[5m])",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} Client Traffic In",
+              "legendFormat": "{{`{{instance}}`}} Client Traffic In",
               "metric": "etcd_network_client_grpc_received_bytes_total",
               "refId": "A",
               "step": 4
@@ -787,7 +787,7 @@ data:
             {
               "expr": "rate(etcd_network_client_grpc_sent_bytes_total{taco_cluster=\"$taco_cluster\"}[5m])",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} Client Traffic Out",
+              "legendFormat": "{{`{{instance}}`}} Client Traffic Out",
               "metric": "etcd_network_client_grpc_sent_bytes_total",
               "refId": "A",
               "step": 4
@@ -882,7 +882,7 @@ data:
             {
               "expr": "sum(rate(etcd_network_peer_received_bytes_total{taco_cluster=\"$taco_cluster\"}[5m])) by (instance)",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} Peer Traffic In",
+              "legendFormat": "{{`{{instance}}`}} Peer Traffic In",
               "metric": "etcd_network_peer_received_bytes_total",
               "refId": "A",
               "step": 4
@@ -980,7 +980,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} Peer Traffic Out",
+              "legendFormat": "{{`{{instance}}`}} Peer Traffic Out",
               "metric": "etcd_network_peer_sent_bytes_total",
               "refId": "A",
               "step": 4
@@ -1073,7 +1073,7 @@ data:
             {
               "expr": "process_resident_memory_bytes{taco_cluster=\"$taco_cluster\"}",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} Resident Memory",
+              "legendFormat": "{{`{{instance}}`}} Resident Memory",
               "metric": "process_resident_memory_bytes",
               "refId": "A",
               "step": 4
@@ -1169,7 +1169,7 @@ data:
               "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{taco_cluster=\"$taco_cluster\"}[5m])) by (instance, le))",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} WAL fsync",
+              "legendFormat": "{{`{{instance}}`}} WAL fsync",
               "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
               "refId": "A",
               "step": 4
@@ -1177,7 +1177,7 @@ data:
             {
               "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{taco_cluster=\"$taco_cluster\"}[5m])) by (instance, le))",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} DB fsync",
+              "legendFormat": "{{`{{instance}}`}} DB fsync",
               "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
               "refId": "B",
               "step": 4
@@ -1391,7 +1391,7 @@ data:
             {
               "expr": "changes(etcd_server_leader_changes_seen_total{taco_cluster=\"$taco_cluster\"}[1d])",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} Total Leader Elections Per Day",
+              "legendFormat": "{{`{{instance}}`}} Total Leader Elections Per Day",
               "metric": "etcd_server_leader_changes_seen_total",
               "refId": "A",
               "step": 2

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-f5status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-f5status.yaml
@@ -102,7 +102,7 @@ data:
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{{pod}} : {{node}}",
+              "legendFormat": "{{`{{pod}}`}} : {{`{{node}}`}}",
               "refId": "A",
               "step": 2
             }
@@ -202,7 +202,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{pod}} : {{node}}",
+              "legendFormat": "{{`{{pod}}`}} : {{`{{node}}`}}",
               "metric": "container_memory_usage_bytes",
               "refId": "A",
               "step": 10
@@ -306,7 +306,7 @@ data:
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{{pod}} : {{node}}",
+              "legendFormat": "{{`{{pod}}`}} : {{`{{node}}`}}",
               "refId": "A",
               "step": 2
             }
@@ -406,7 +406,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{pod}} : {{node}}",
+              "legendFormat": "{{`{{pod}}`}} : {{`{{node}}`}}",
               "metric": "container_memory_usage_bytes",
               "refId": "A",
               "step": 10
@@ -510,7 +510,7 @@ data:
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{{ pod}} : {{node}}",
+              "legendFormat": "{{`{{ pod}}`}} : {{`{{node}}`}}",
               "refId": "A",
               "step": 2
             }
@@ -610,7 +610,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{ pod}} : {{node}}",
+              "legendFormat": "{{`{{ pod}}`}} : {{`{{node}}`}}",
               "metric": "container_memory_usage_bytes",
               "refId": "A",
               "step": 10
@@ -727,7 +727,7 @@ data:
             {
               "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-suy-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[1m]))by(namespace) ",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}",
+              "legendFormat": "{{`{{namespace}}`}}",
               "refId": "A"
             }
           ],
@@ -875,7 +875,7 @@ data:
             {
               "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-ssu-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[1m]))by(namespace) ",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}",
+              "legendFormat": "{{`{{namespace}}`}}",
               "refId": "A"
             }
           ],
@@ -1040,7 +1040,7 @@ data:
               "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-suy-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[30s]))by(taco_cluster, svc) ",
               "hide": false,
               "instant": false,
-              "legendFormat": "{{taco_cluster}}:: {{svc}}",
+              "legendFormat": "{{`{{taco_cluster}}`}}:: {{`{{svc}}`}}",
               "refId": "A"
             }
           ],
@@ -1142,7 +1142,7 @@ data:
               "expr": "sum(rate(f5_pool_member_requests{taco_cluster=~\"skb-ssu-prd.*\", namespace=~\"metv|scs|stb|common.*\"}[30s]))by(taco_cluster, svc) ",
               "hide": false,
               "instant": false,
-              "legendFormat": "{{taco_cluster}}:: {{svc}}",
+              "legendFormat": "{{`{{taco_cluster}}`}}:: {{`{{svc}}`}}",
               "refId": "A"
             }
           ],

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-cluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-cluster.yaml
@@ -1324,7 +1324,7 @@ data:
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{status=\"true\",condition=\"Ready\",taco_cluster=~\"$taco_cluster\"}) by (node)",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -1573,7 +1573,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_cpu_cores{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -1660,7 +1660,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_memory_bytes{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -1792,7 +1792,7 @@ data:
               "expr": " count(count by (pod)(kube_pod_container_info{taco_cluster=~\"$taco_cluster\"}))",
               "hide": false,
               "instant": true,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{`{{pod}}`}}",
               "refId": "A"
             },
             {
@@ -1989,7 +1989,7 @@ data:
               "expr": "count(kube_pod_container_status_waiting{taco_cluster=~\"$taco_cluster\"} !=0 ) or vector(0)",
               "hide": false,
               "instant": true,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{`{{pod}}`}}",
               "refId": "A"
             }
           ],
@@ -2062,7 +2062,7 @@ data:
             {
               "expr": "count by(namespace,reason) (kube_pod_container_status_waiting_reason{taco_cluster=~\"$taco_cluster\"} !=0 )",
               "hide": false,
-              "legendFormat": "WAITING::{{reason}}::{{namespace}}",
+              "legendFormat": "WAITING::{{`{{reason}}`}}::{{`{{namespace}}`}}",
               "refId": "B"
             },
             {
@@ -2183,7 +2183,7 @@ data:
               "expr": "count(kube_pod_container_status_terminated_reason{reason!=\"Completed\",taco_cluster=~\"$taco_cluster\"} !=0 ) or vector(0)",
               "hide": false,
               "instant": true,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{`{{pod}}`}}",
               "refId": "A"
             }
           ],
@@ -2257,7 +2257,7 @@ data:
               "expr": "count by(namespace,reason) (kube_pod_container_status_terminated_reason{reason!=\"Completed\",taco_cluster=~\"$taco_cluster\"} !=0 )",
               "hide": false,
               "instant": false,
-              "legendFormat": "TERMINATED::{{reason}}::{{namespace}}",
+              "legendFormat": "TERMINATED::{{`{{reason}}`}}::{{`{{namespace}}`}}",
               "refId": "A"
             }
           ],
@@ -2363,7 +2363,7 @@ data:
             {
               "expr": "(kubelet_volume_stats_used_bytes {taco_cluster=\"$taco_cluster\"} / kubelet_volume_stats_capacity_bytes {taco_cluster=\"$taco_cluster\"}) * 100 ",
               "instant": true,
-              "legendFormat": "{{persistentvolumeclaim}}",
+              "legendFormat": "{{`{{persistentvolumeclaim}}`}}",
               "refId": "A"
             }
           ],

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-overview.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-overview.yaml
@@ -2121,7 +2121,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -2178,7 +2178,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -2237,7 +2237,7 @@ data:
               "expr": "sort_desc (count by (node) (kube_pod_info{taco_cluster=\"skb-ssu-prd02\", created_by_kind != \"Workflow\"}))",
               "format": "time_series",
               "instant": true,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -2294,7 +2294,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -2353,7 +2353,7 @@ data:
               "expr": "sort_desc (count by (node) (kube_pod_info{taco_cluster=\"skb-suy-adm01\", created_by_kind != \"Workflow\"}))",
               "format": "time_series",
               "instant": true,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -2410,7 +2410,7 @@ data:
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -2512,7 +2512,7 @@ data:
             {
               "expr": "kube_deployment_spec_replicas{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
               "instant": true,
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -2734,7 +2734,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_spec_replicas{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -2823,7 +2823,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -3081,7 +3081,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_available{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -3170,7 +3170,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_unavailable{namespace=\"kube-system\", taco_cluster=\"$taco_cluster\"}  ",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -3271,7 +3271,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_cpu_cores{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -3358,7 +3358,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_node_status_allocatable_cpu_cores{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -3445,7 +3445,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_pod_container_resource_requests_memory_bytes{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],
@@ -3532,7 +3532,7 @@ data:
           "targets": [
             {
               "expr": "sum by (node) (kube_node_status_allocatable_memory_bytes{taco_cluster=\"$taco_cluster\"})",
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A"
             }
           ],

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-pods.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-pods.yaml
@@ -681,7 +681,7 @@ data:
               "expr": "sum(avg(kube_pod_status_phase{taco_cluster=~\"$taco_cluster\"}) by(pod, phase)) by(phase)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{ phase }}",
+              "legendFormat": "{{`{{ phase }}`}}",
               "refId": "A",
               "step": 2
             }
@@ -779,7 +779,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{ pod }}",
+              "legendFormat": "{{`{{ pod }}`}}",
               "refId": "A",
               "step": 2
             }
@@ -973,7 +973,7 @@ data:
               "expr": "sum(avg(kube_pod_status_phase{taco_cluster=~\"$taco_cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}) by(namespace, pod, phase)) by(phase)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{ phase }}",
+              "legendFormat": "{{`{{ phase }}`}}",
               "refId": "A",
               "step": 2
             }
@@ -1071,7 +1071,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{ pod }}",
+              "legendFormat": "{{`{{ pod }}`}}",
               "refId": "A",
               "step": 2
             }
@@ -1267,23 +1267,23 @@ data:
               "expr": "kube_deployment_status_replicas{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current: {{ deployment }}",
+              "legendFormat": "current: {{`{{ deployment }}`}}",
               "refId": "A",
               "step": 2
             },
             {
               "expr": "kube_deployment_status_replicas_available{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "available: {{ deployment }}",
+              "legendFormat": "available: {{`{{ deployment }}`}}",
               "refId": "C"
             },
             {
               "expr": "kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "unavailable: {{ deployment }}",
+              "legendFormat": "unavailable: {{`{{ deployment }}`}}",
               "refId": "B"
             },
             {
               "expr": "kube_deployment_spec_replicas{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "deseired: {{ deployment }}",
+              "legendFormat": "deseired: {{`{{ deployment }}`}}",
               "refId": "D"
             }
           ],
@@ -1455,7 +1455,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_spec_replicas{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -1627,7 +1627,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -1799,7 +1799,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_available{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -1971,7 +1971,7 @@ data:
           "targets": [
             {
               "expr": "kube_deployment_status_replicas_unavailable{taco_cluster=\"$taco_cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -2079,7 +2079,7 @@ data:
             {
               "expr": "kube_deployment_spec_replicas{namespace=\"$namespace\", taco_cluster=\"$taco_cluster\"}",
               "instant": true,
-              "legendFormat": "{{deployment}}",
+              "legendFormat": "{{`{{deployment}}`}}",
               "refId": "A"
             }
           ],
@@ -2235,20 +2235,20 @@ data:
           "targets": [
             {
               "expr": "kube_statefulset_status_replicas{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "desired: {{ statefulset }}",
+              "legendFormat": "desired: {{`{{ statefulset }}`}}",
               "refId": "B"
             },
             {
               "expr": "kube_statefulset_status_replicas_current{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current: {{ statefulset }}",
+              "legendFormat": "current: {{`{{ statefulset }}`}}",
               "refId": "A",
               "step": 2
             },
             {
               "expr": "kube_statefulset_status_replicas_ready{namespace=~\"$namespace\", taco_cluster=\"$taco_cluster\"}",
-              "legendFormat": "ready: {{ statefulset }}",
+              "legendFormat": "ready: {{`{{ statefulset }}`}}",
               "refId": "C"
             }
           ],
@@ -2530,7 +2530,7 @@ data:
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "Current: {{ container }}",
+              "legendFormat": "Current: {{`{{ container }}`}}",
               "refId": "A",
               "step": 2
             },
@@ -2539,7 +2539,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "Requested: {{ container }}",
+              "legendFormat": "Requested: {{`{{ container }}`}}",
               "refId": "B",
               "step": 2
             },
@@ -2548,7 +2548,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "Limit: {{ container }}",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
               "refId": "C",
               "step": 2
             }
@@ -2814,7 +2814,7 @@ data:
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 1,
-              "legendFormat": "Current: {{ container  }}",
+              "legendFormat": "Current: {{`{{ container  }}`}}",
               "metric": "container_memory_usage_bytes",
               "refId": "A",
               "step": 10
@@ -2824,7 +2824,7 @@ data:
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 2,
-              "legendFormat": "Requested: {{ container }}",
+              "legendFormat": "Requested: {{`{{ container }}`}}",
               "metric": "kube_pod_container_resource_requests_memory_bytes",
               "refId": "B",
               "step": 20
@@ -2834,7 +2834,7 @@ data:
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 2,
-              "legendFormat": "Limit: {{ container }}",
+              "legendFormat": "Limit: {{`{{ container }}`}}",
               "metric": "kube_pod_container_resource_limits_memory_bytes",
               "refId": "C",
               "step": 20
@@ -3102,7 +3102,7 @@ data:
               "expr": "rate (container_network_transmit_bytes_total{taco_cluster=~\"$taco_cluster\", namespace=\"$namespace\", pod=~\"$pod\",interface=~\"eth0|ens.*\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "TX : {{ pod }}",
+              "legendFormat": "TX : {{`{{ pod }}`}}",
               "refId": "A",
               "step": 2
             },
@@ -3110,7 +3110,7 @@ data:
               "expr": "rate (container_network_receive_bytes_total{taco_cluster=~\"$taco_cluster\", namespace=\"$namespace\", pod=~\"$pod\",interface=~\"eth0|ens.*\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "RX : {{ pod }}",
+              "legendFormat": "RX : {{`{{ pod }}`}}",
               "refId": "B",
               "step": 2
             }

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-node-networks.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-node-networks.yaml
@@ -120,7 +120,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive",
+              "legendFormat": "{{`{{device}}`}} - Receive",
               "refId": "O",
               "step": 4
             },
@@ -129,7 +129,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit",
+              "legendFormat": "{{`{{device}}`}} - Transmit",
               "refId": "P",
               "step": 4
             },
@@ -137,7 +137,7 @@ data:
               "expr": "irate(node_network_receive_packets_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive",
+              "legendFormat": "{{`{{device}}`}} - Receive",
               "refId": "A",
               "step": 4
             },
@@ -145,7 +145,7 @@ data:
               "expr": "irate(node_network_transmit_packets_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit",
+              "legendFormat": "{{`{{device}}`}} - Transmit",
               "refId": "B",
               "step": 4
             }
@@ -277,7 +277,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive errors",
+              "legendFormat": "{{`{{device}}`}} - Receive errors",
               "refId": "E",
               "step": 4
             },
@@ -286,7 +286,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit errors",
+              "legendFormat": "{{`{{device}}`}} - Transmit errors",
               "refId": "F",
               "step": 4
             },
@@ -295,7 +295,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive errors",
+              "legendFormat": "{{`{{device}}`}} - Receive errors",
               "refId": "A",
               "step": 4
             },
@@ -304,7 +304,7 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit errors",
+              "legendFormat": "{{`{{device}}`}} - Transmit errors",
               "refId": "B",
               "step": 4
             }
@@ -436,7 +436,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive drop",
+              "legendFormat": "{{`{{device}}`}} - Receive drop",
               "refId": "G",
               "step": 4
             },
@@ -445,7 +445,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit drop",
+              "legendFormat": "{{`{{device}}`}} - Transmit drop",
               "refId": "H",
               "step": 4
             },
@@ -453,7 +453,7 @@ data:
               "expr": "irate(node_network_receive_drop_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive drop",
+              "legendFormat": "{{`{{device}}`}} - Receive drop",
               "refId": "A",
               "step": 4
             },
@@ -461,7 +461,7 @@ data:
               "expr": "irate(node_network_transmit_drop_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit drop",
+              "legendFormat": "{{`{{device}}`}} - Transmit drop",
               "refId": "B",
               "step": 4
             }
@@ -593,7 +593,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive compressed",
+              "legendFormat": "{{`{{device}}`}} - Receive compressed",
               "refId": "C",
               "step": 4
             },
@@ -602,7 +602,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit compressed",
+              "legendFormat": "{{`{{device}}`}} - Transmit compressed",
               "refId": "D",
               "step": 4
             },
@@ -610,7 +610,7 @@ data:
               "expr": "irate(node_network_receive_compressed_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive compressed",
+              "legendFormat": "{{`{{device}}`}} - Receive compressed",
               "refId": "A",
               "step": 4
             },
@@ -618,7 +618,7 @@ data:
               "expr": "irate(node_network_transmit_compressed_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit compressed",
+              "legendFormat": "{{`{{device}}`}} - Transmit compressed",
               "refId": "B",
               "step": 4
             }
@@ -751,7 +751,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive multicast",
+              "legendFormat": "{{`{{device}}`}} - Receive multicast",
               "refId": "M",
               "step": 4
             },
@@ -759,21 +759,21 @@ data:
               "expr": "irate(node_network_transmit_multicast{instance=~\"$server\"}[5m])",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit multicast",
+              "legendFormat": "{{`{{device}}`}} - Transmit multicast",
               "refId": "A"
             },
             {
               "expr": "irate(node_network_receive_multicast_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive multicast",
+              "legendFormat": "{{`{{device}}`}} - Receive multicast",
               "refId": "B",
               "step": 4
             },
             {
               "expr": "irate(node_network_transmit_multicast_total{instance=~\"$server\"}[5m])",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit multicast",
+              "legendFormat": "{{`{{device}}`}} - Transmit multicast",
               "refId": "C"
             }
           ],
@@ -904,7 +904,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive fifo",
+              "legendFormat": "{{`{{device}}`}} - Receive fifo",
               "refId": "I",
               "step": 4
             },
@@ -913,7 +913,7 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit fifo",
+              "legendFormat": "{{`{{device}}`}} - Transmit fifo",
               "refId": "J",
               "step": 4
             },
@@ -921,7 +921,7 @@ data:
               "expr": "irate(node_network_receive_fifo_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive fifo",
+              "legendFormat": "{{`{{device}}`}} - Receive fifo",
               "refId": "A",
               "step": 4
             },
@@ -929,7 +929,7 @@ data:
               "expr": "irate(node_network_transmit_fifo_total{instance=~\"$server\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Transmit fifo",
+              "legendFormat": "{{`{{device}}`}} - Transmit fifo",
               "refId": "B",
               "step": 4
             }
@@ -1061,14 +1061,14 @@ data:
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive frame",
+              "legendFormat": "{{`{{device}}`}} - Receive frame",
               "refId": "K",
               "step": 4
             },
             {
               "expr": "irate(node_network_transmit_frame{instance=~\"$server\"}[5m])",
               "hide": true,
-              "legendFormat": "{{device}} - Transmit frame",
+              "legendFormat": "{{`{{device}}`}} - Transmit frame",
               "refId": "A"
             },
             {
@@ -1076,13 +1076,13 @@ data:
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{device}} - Receive frame",
+              "legendFormat": "{{`{{device}}`}} - Receive frame",
               "refId": "B",
               "step": 4
             },
             {
               "expr": "irate(node_network_transmit_frame_total{instance=~\"$server\"}[5m])",
-              "legendFormat": "{{device}} - Transmit frame",
+              "legendFormat": "{{`{{device}}`}} - Transmit frame",
               "refId": "C"
             }
           ],
@@ -1281,7 +1281,7 @@ data:
               "expr": "node_arp_entries{instance=~\"$server\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{ device }} - ARP entries",
+              "legendFormat": "{{`{{ device }}`}} - ARP entries",
               "refId": "A",
               "step": 4
             }

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-nodestatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-nodestatus.yaml
@@ -106,7 +106,7 @@ data:
               "expr": "sort (sum(kube_node_status_condition{status=\"true\",condition=\"Ready\",taco_cluster=~\"$taco_cluster\"}) by (node))",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{`{{node}}`}}",
               "refId": "A",
               "units": "none",
               "valueHandler": "Number Threshold"
@@ -576,7 +576,7 @@ data:
               "expr": "(1 - avg(irate(node_cpu_seconds_total{job=~\"$job\",mode=\"idle\", taco_cluster=\"$taco_cluster\"}[5m])) by (instance)) * 100 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
               "format": "time_series",
               "intervalFactor": 3,
-              "legendFormat": "{{nodename}}",
+              "legendFormat": "{{`{{nodename}}`}}",
               "refId": "A"
             }
           ],
@@ -664,7 +664,7 @@ data:
           "targets": [
             {
               "expr": "(1 - (node_memory_MemAvailable_bytes{job=~\"$job\", taco_cluster=\"$taco_cluster\"} / (node_memory_MemTotal_bytes{job=~\"$job\", taco_cluster=\"$taco_cluster\"})))* 100 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{nodename}}",
+              "legendFormat": "{{`{{nodename}}`}}",
               "refId": "A"
             }
           ],
@@ -752,7 +752,7 @@ data:
           "targets": [
             {
               "expr": "max((node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}) *100/(node_filesystem_avail_bytes {job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}+(node_filesystem_size_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"}-node_filesystem_free_bytes{job=~\"$job\",fstype=~\"ext.?|xfs\",taco_cluster=\"$taco_cluster\"})))by(instance) + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{nodename}}",
+              "legendFormat": "{{`{{nodename}}`}}",
               "refId": "A"
             }
           ],
@@ -840,7 +840,7 @@ data:
           "targets": [
             {
               "expr": "sum by (instance) (irate(node_network_transmit_bytes_total{device=~\"ens\\\\w*\", taco_cluster=~\"$taco_cluster\"}[5m])) * 8 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{nodename}}",
+              "legendFormat": "{{`{{nodename}}`}}",
               "refId": "A"
             }
           ],
@@ -928,7 +928,7 @@ data:
           "targets": [
             {
               "expr": "sum by (instance) (irate(node_network_receive_bytes_total{device=~\"ens\\\\w*\", taco_cluster=~\"$taco_cluster\"}[5m])) * 8 + on(instance) group_left(nodename) \nnode_uname_info{taco_cluster=~\"$taco_cluster\"}",
-              "legendFormat": "{{nodename}}",
+              "legendFormat": "{{`{{nodename}}`}}",
               "refId": "A"
             }
           ],
@@ -2013,7 +2013,7 @@ data:
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{`{{instance}}`}}",
               "refId": "A",
               "step": 20
             }
@@ -2665,7 +2665,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{mountpoint}}",
+              "legendFormat": "{{`{{mountpoint}}`}}",
               "refId": "A"
             }
           ],
@@ -2779,7 +2779,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_Read bytes",
+              "legendFormat": "{{`{{device}}`}}_Read bytes",
               "refId": "A",
               "step": 10
             },
@@ -2789,7 +2789,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_Written bytes",
+              "legendFormat": "{{`{{device}}`}}_Written bytes",
               "refId": "B",
               "step": 10
             }
@@ -2905,7 +2905,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_Read time",
+              "legendFormat": "{{`{{device}}`}}_Read time",
               "refId": "B"
             },
             {
@@ -2915,7 +2915,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_Write time",
+              "legendFormat": "{{`{{device}}`}}_Write time",
               "refId": "C"
             }
           ],
@@ -3028,7 +3028,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_Reads completed",
+              "legendFormat": "{{`{{device}}`}}_Reads completed",
               "refId": "A",
               "step": 10
             },
@@ -3038,7 +3038,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_Writes completed",
+              "legendFormat": "{{`{{device}}`}}_Writes completed",
               "refId": "B",
               "step": 10
             }
@@ -3160,7 +3160,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{device}}_ IO time",
+              "legendFormat": "{{`{{device}}`}}_ IO time",
               "refId": "C"
             }
           ],
@@ -3755,7 +3755,7 @@ data:
           "renderer": "flot",
           "seriesOverrides": [
             {
-              "alias": "{{ pod }}",
+              "alias": "{{`{{ pod }}`}}",
               "fill": 1,
               "fillGradient": 1
             },
@@ -3771,7 +3771,7 @@ data:
           "targets": [
             {
               "expr": "sort_desc (sum by (pod) (rate(container_cpu_usage_seconds_total{taco_cluster=~\"$taco_cluster\", node=\"$show_hostname\", image!=\"\"}[2m])))",
-              "legendFormat": "{{ pod }}",
+              "legendFormat": "{{`{{ pod }}`}}",
               "refId": "B"
             }
           ],
@@ -3881,7 +3881,7 @@ data:
           "targets": [
             {
               "expr": "avg by(pod) (container_memory_working_set_bytes{taco_cluster=~\"$taco_cluster\", node=\"$show_hostname\",container!=\"POD\",container!=\"\",image!=\"\"})",
-              "legendFormat": "{{ pod }}",
+              "legendFormat": "{{`{{ pod }}`}}",
               "refId": "B"
             }
           ],
@@ -4007,7 +4007,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{`{{pod}}`}}",
               "refId": "A",
               "step": 20
             }
@@ -4132,7 +4132,7 @@ data:
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{`{{pod}}`}}",
               "refId": "A",
               "step": 20
             }
@@ -4293,14 +4293,14 @@ data:
               "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=~'$node'}[5m])",
               "hide": true,
               "interval": "",
-              "legendFormat": "{{instance}}_Tcp_PassiveOpens",
+              "legendFormat": "{{`{{instance}}`}}_Tcp_PassiveOpens",
               "refId": "G"
             },
             {
               "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=~'$node'}[5m])",
               "hide": true,
               "interval": "",
-              "legendFormat": "{{instance}}_Tcp_ActiveOpens",
+              "legendFormat": "{{`{{instance}}`}}_Tcp_ActiveOpens",
               "refId": "F"
             },
             {

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-tridentstatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-tridentstatus.yaml
@@ -101,7 +101,7 @@ data:
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{`{{pod}}`}}",
               "refId": "A",
               "step": 2
             }
@@ -200,7 +200,7 @@ data:
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{pod}} ",
+              "legendFormat": "{{`{{pod}}`}}",
               "metric": "container_memory_usage_bytes",
               "refId": "A",
               "step": 10
@@ -312,7 +312,7 @@ data:
               "expr": "(kubelet_volume_stats_used_bytes {taco_cluster=\"$taco_cluster\"} / kubelet_volume_stats_capacity_bytes {taco_cluster=\"$taco_cluster\"}) * 100 ",
               "instant": true,
               "intervalFactor": 1,
-              "legendFormat": "{{persistentvolumeclaim}}",
+              "legendFormat": "{{`{{persistentvolumeclaim}}`}}",
               "refId": "A"
             }
           ],
@@ -380,7 +380,7 @@ data:
               "expr": "trident_core_backend_info{backend_type=\"ontap-nas\"}",
               "instant": false,
               "interval": "",
-              "legendFormat": "{{backend_name}}:{{taco_cluster}}",
+              "legendFormat": "{{`{{backend_name}}`}}:{{`{{taco_cluster}}`}}",
               "refId": "A"
             }
           ],
@@ -471,7 +471,7 @@ data:
               "displayValueWithAlias": "Never",
               "expr": "sum by (operation) (trident_operation_duration_milliseconds_sum{success=\"true\"}) / sum by (operation) (trident_operation_duration_milliseconds_count{success=\"true\"})",
               "instant": false,
-              "legendFormat": "{{ operation }}",
+              "legendFormat": "{{`{{ operation }}`}}",
               "refId": "A",
               "units": "none",
               "valueHandler": "Number Threshold"
@@ -526,7 +526,7 @@ data:
             {
               "expr": "sort (trident_core_volume_count{taco_cluster=~\"skb.*\"} + on(backend_uuid) group_left(backend_name) trident_backend_info {taco_cluster=~\"skb.*\"})",
               "instant": true,
-              "legendFormat": "{{ taco_cluster }}::{{ backend_name }}",
+              "legendFormat": "{{`{{ taco_cluster }}`}}::{{`{{ backend_name }}`}}",
               "refId": "A"
             }
           ],
@@ -575,7 +575,7 @@ data:
             {
               "expr": "trident_core_volume_total_bytes / 1024 / 1024 / 1024",
               "instant": true,
-              "legendFormat": "{{taco_cluster}}",
+              "legendFormat": "{{`{{taco_cluster}}`}}",
               "refId": "A"
             }
           ],
@@ -629,7 +629,7 @@ data:
               "expr": "trident_core_volume_count_by_backend",
               "instant": false,
               "interval": "",
-              "legendFormat": "{{backend}}:{{taco_cluster}}",
+              "legendFormat": "{{`{{backend}}`}}:{{`{{taco_cluster}}`}}",
               "refId": "A"
             }
           ],
@@ -719,7 +719,7 @@ data:
           "targets": [
             {
               "expr": "trident_core_volume_total_bytes_by_backend / 1024 / 1024 / 1024",
-              "legendFormat": "{{backend}}:{{taco_cluster}}",
+              "legendFormat": "{{`{{backend}}`}}:{{`{{taco_cluster}}`}}",
               "refId": "A"
             }
           ],
@@ -889,7 +889,7 @@ data:
               "displayValueWithAlias": "Never",
               "expr": "(sum (trident_rest_ops_seconds_total_count{taco_cluster=\"$taco_cluster\"}) by (status_code)  / scalar (sum (trident_rest_ops_seconds_total_count{taco_cluster=\"$taco_cluster\"}))) * 100",
               "instant": false,
-              "legendFormat": "{{ status_code }}",
+              "legendFormat": "{{`{{ status_code }}`}}",
               "refId": "A",
               "units": "none",
               "valueHandler": "Number Threshold"


### PR DESCRIPTION
* {{ }} 문법은 go template과 grafana의 template이 겹친다.
* 따라서 grafana에서 사용하는 {{ }}는 일반 string으로 여겨질 수 있도록 {{` `}} 로 감싼다.