### PR TITLE
Delete helm hook-delete-policy from fluentbit-operator chart

### DIFF
--- a/fluentbit-operator/Chart.yaml
+++ b/fluentbit-operator/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
   email: usnexp@gmail.com
 sources:
 - https://github.com/intelliguy/fluentbit-operator
-version: 1.0.9
+version: 1.0.10

--- a/fluentbit-operator/templates/fluentbit/cm-cr.yaml
+++ b/fluentbit-operator/templates/fluentbit/cm-cr.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded  
   labels:
     app: {{ template "fluentbit-operator.name" . }}-operator
 {{ include "fluentbit-operator.labels" . | indent 4 }}

--- a/fluentbit-operator/templates/fluentbit/job-es-template.yaml
+++ b/fluentbit-operator/templates/fluentbit/job-es-template.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "fluentbit-operator.name" . }}-operator
 {{ include "fluentbit-operator.labels" . | indent 4 }}


### PR DESCRIPTION
* fluentbit-operator차트의 fluentbit 부분에서 configmap과 job이 helm delete 이후에도 계속 남아있는 문제
* cr-cm configmap 의 경우, helm의 hook-delete-policy가 `hook-succeeded`면 hook 성공 이후 삭제한다는 의미이지만 configmap은 
삭제 대상이 아님. (실제 complete이 되는 resource가 아니라서 삭제도 안되는 걸로 보임)
* job-es-template의 경우, job complete 후 삭제될 수 있지만, 만약 재설치 or 업그레이드시 이전 job이 있다면 재생성 할 수 있도록 `before-hook-creation` 을 넣음.