### PR TITLE
update service-mesh-resource chart

### DIFF
--- a/service-mesh-resource/Chart.yaml
+++ b/service-mesh-resource/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/service-mesh-resource/templates/istio-controlplane.yaml
+++ b/service-mesh-resource/templates/istio-controlplane.yaml
@@ -19,10 +19,10 @@ spec:
     defaultConfig:
       discoveryAddress: "istiod-{{ .Values.IstioOperator.revision }}.{{ .Values.IstioOperator.istioNamespace }}.svc:15012"
       tracing:
-        sampling: {{ .Values.IstioOperator.meshConfig.tracing_sampling }}
-      {{- if .Values.IstioOperator.meshConfig.tracing_url }}
+        sampling: {{ .Values.IstioOperator.meshConfig.tracingSampling }}
+      {{- if .Values.IstioOperator.meshConfig.tracingUrl }}
         zipkin:
-          address: {{ .Values.IstioOperator.meshConfig.tracing_url }}
+          address: {{ .Values.IstioOperator.meshConfig.tracingUrl }}
       {{- end }}
 {{- if .Values.IstioOperator.meshConfig.customTags }}
         custom_tags: 

--- a/service-mesh-resource/templates/istio-controlplane.yaml
+++ b/service-mesh-resource/templates/istio-controlplane.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.IstioOperator.enabled }}
+{{- if .Values.IstioOperator.enableControlplane }}
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
@@ -10,15 +10,6 @@ spec:
   {{- if .Values.IstioOperator.profile }}
   profile: {{ .Values.IstioOperator.profile }}
   {{- end }}
-  components:
-{{- if .Values.IstioOperator.ingressGateways }}
-    ingressGateways:
-{{ toYaml .Values.IstioOperator.ingressGateways | indent 6 }}
-{{- end }}
-{{- if .Values.IstioOperator.egressGateways }}
-    egressGateways:
-{{ toYaml .Values.IstioOperator.egressGateways | indent 6 }}
-{{- end }}
   meshConfig:
     {{- if .Values.IstioOperator.meshConfig.enableAccessLog }}
     accessLogFile: "/dev/stdout"
@@ -28,13 +19,11 @@ spec:
     defaultConfig:
       discoveryAddress: "istiod-{{ .Values.IstioOperator.revision }}.{{ .Values.IstioOperator.istioNamespace }}.svc:15012"
       tracing:
-        sampling: {{ .Values.IstioOperator.meshConfig.tracing_sampling | default 100 }}
+        sampling: {{ .Values.IstioOperator.meshConfig.tracing_sampling }}
       {{- if .Values.IstioOperator.meshConfig.tracing_url }}
         zipkin:
           address: {{ .Values.IstioOperator.meshConfig.tracing_url }}
       {{- end }}
-
-
 {{- if .Values.IstioOperator.meshConfig.customTags }}
         custom_tags: 
 {{ toYaml .Values.IstioOperator.meshConfig.customTags | indent 10 }}

--- a/service-mesh-resource/templates/istio-gateway.yaml
+++ b/service-mesh-resource/templates/istio-gateway.yaml
@@ -36,6 +36,8 @@ spec:
               apiVersion: apps/v1
               kind: Deployment
               name: istio-ingressgateway-{{- $gateway.name }}
+          service:
+            type: {{ default "LoadBalancer" $gateway.serviceType }}
 {{- end }}
 {{- end }}
 {{- if .Values.IstioOperator.egressGateways }}

--- a/service-mesh-resource/templates/istio-gateway.yaml
+++ b/service-mesh-resource/templates/istio-gateway.yaml
@@ -26,7 +26,7 @@ spec:
               memory: {{ default "2048Mi" $gateway.resources.limits_memory }}
           hpaSpec:
             maxReplicas: {{ default 10 $gateway.hpaMaxReplicas }}
-            minReplicas: 2
+            minReplicas: {{ default 2 $gateway.hpaMinReplicas }}
             metrics:
             - resource:
                 name: cpu
@@ -58,7 +58,7 @@ spec:
               memory: {{ default "2048Mi" $gateway.resources.limits_memory }}
           hpaSpec:
             maxReplicas: {{ default 10 $gateway.hpaMaxReplicas }}
-            minReplicas: 2
+            minReplicas: {{ default 2 $gateway.hpaMinReplicas }}
             metrics:
             - resource:
                 name: cpu

--- a/service-mesh-resource/templates/istio-gateway.yaml
+++ b/service-mesh-resource/templates/istio-gateway.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.IstioOperator.enableGateway }}
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio-gateway
+  namespace: istio-gateway
+spec:
+  revision: {{ .Values.IstioOperator.revision }}
+  profile: empty
+  components:
+{{- if .Values.IstioOperator.ingressGateways }}
+    ingressGateways:
+{{- range $gateway := .Values.IstioOperator.ingressGateways }}
+      - name: istio-ingressgateway-{{- $gateway.name }}
+        enabled: true
+        namespace: istio-gateway
+        label:
+          istio: ingressgateway-{{- $gateway.name }}
+        k8s:
+          resources:
+            requests:
+              cpu: {{ default "1000m" $gateway.resources.requests_cpu }}
+              memory: {{ default "1024Mi" $gateway.resources.requests_memory }}
+            limits:
+              cpu: {{ default "2000m" $gateway.resources.limits_cpu }}
+              memory: {{ default "2048Mi" $gateway.resources.limits_memory }}
+          hpaSpec:
+            maxReplicas: {{ default 10 $gateway.hpaMaxReplicas }}
+            minReplicas: 2
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: {{ default 80 $gateway.hpaTargetCpuUilization }}
+              type: Resource
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-ingressgateway-{{- $gateway.name }}
+{{- end }}
+{{- end }}
+{{- if .Values.IstioOperator.egressGateways }}
+    egressGateways:
+{{- range $gateway := .Values.IstioOperator.egressGateways }}
+      - name: istio-egressgateway-{{- $gateway.name }}
+        enabled: true
+        namespace: istio-gateway
+        label:
+          istio: egressgateway-{{- $gateway.name }}
+        k8s:
+          resources:
+            requests:
+              cpu: {{ default "1000m" $gateway.resources.requests_cpu }}
+              memory: {{ default "1024Mi" $gateway.resources.requests_memory }}
+            limits:
+              cpu: {{ default "2000m" $gateway.resources.limits_cpu }} 
+              memory: {{ default "2048Mi" $gateway.resources.limits_memory }}
+          hpaSpec:
+            maxReplicas: {{ default 10 $gateway.hpaMaxReplicas }}
+            minReplicas: 2
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: {{ default 80 $gateway.hpaTargetCpuUilization }}
+              type: Resource
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-egressgateway-{{- $gateway.name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/service-mesh-resource/templates/istio-operator.yaml
+++ b/service-mesh-resource/templates/istio-operator.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: istio-system
   name: istio-controlplane
 spec:
+  revision: {{ .Values.IstioOperator.revision }}
+  namespace: {{ .Values.IstioOperator.istioNamespace }}
   {{- if .Values.IstioOperator.profile }}
   profile: {{ .Values.IstioOperator.profile }}
   {{- end }}
@@ -21,12 +23,18 @@ spec:
     {{- if .Values.IstioOperator.meshConfig.enableAccessLog }}
     accessLogFile: "/dev/stdout"
     {{- end }}
-    {{- if .Values.IstioOperator.meshConfig.enableTracing }}
-    enableTracing: true
-    {{- end }}
+    enableTracing: {{ .Values.IstioOperator.meshConfig.enableTracing }}
+    enablePrometheusMerge: {{ .Values.IstioOperator.meshConfig.enablePrometheusMerge }}
     defaultConfig:
+      discoveryAddress: "istiod-{{ .Values.IstioOperator.revision }}.{{ .Values.IstioOperator.istioNamespace }}.svc:15012"
       tracing:
-        sampling: {{ .Values.IstioOperator.meshConfig.sampling | default 100 }}
+        sampling: {{ .Values.IstioOperator.meshConfig.tracing_sampling | default 100 }}
+      {{- if .Values.IstioOperator.meshConfig.tracing_url }}
+        zipkin:
+          address: {{ .Values.IstioOperator.meshConfig.tracing_url }}
+      {{- end }}
+
+
 {{- if .Values.IstioOperator.meshConfig.customTags }}
         custom_tags: 
 {{ toYaml .Values.IstioOperator.meshConfig.customTags | indent 10 }}
@@ -34,9 +42,4 @@ spec:
   values:
     global:
       istioNamespace: {{ .Values.IstioOperator.istioNamespace }}
-      {{- if .Values.IstioOperator.tracing_url }}
-      tracer:
-        zipkin:
-          address: {{ .Values.IstioOperator.tracing_url }}
-      {{- end }}
 {{- end }}

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -1,5 +1,6 @@
 IstioOperator:
-  enabled: true
+  enableControlplane: true
+  enableGateway: false
   # Configuration profile is one of "default, demo, minimal, remote, empty, preview".
   # refer to https://istio.io/latest/docs/setup/additional-setup/config-profiles/
   profile: default 
@@ -16,48 +17,22 @@ IstioOperator:
     tracing_sampling: 100
     tracing_url: jaeger-operator-jaeger-collector.lma.svc:9411
 
-  ingressGateways:
-    # Default ingressGateway config #
-    - name: istio-ingressgateway
-      enabled: true
-      namespace: istio-gateway
-      k8s:
-        resources:
-          requests:
-            cpu: 1000m
-            memory: 1024Mi
-          limits:
-            cpu: 2000m
-            memory: 2048Mi
-        hpaSpec:
-          maxReplicas: 10
-          minReplicas: 1
-          metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-ingressgateway
+  ingressGateways: []
+  # - name: istio-ingressgateway
+  #   resources:
+  #     requests_cpu: 1000m
+  #     requests_memory: 1024Mi
+  #     limits_cpu: 2000m
+  #     limits_memory: 2048Mi
+  #   hpaMaxReplicas: 10
+  #   hpaTargetCpuUtilization: 80
+          
   egressGateways: []
-  #- name: istio-egressgateway
-  #  enabled: true
-  #  # namespace: istio-gateway
-  #  # label:
-  #  #   custom_label: custom_value
-  #  k8s:
-  #    resources:
-  #      requests:
-  #        cpu: 500m # default 500m
-  #        memory: 1024Mi # default 2048Mi
-  #      limits:
-  #        cpu: 1000m # default 500m
-  #        memory: 2048Mi # default 2048Mi
-  #    hpaSpec:
-  #      maxReplicas: 10 # default 5
-  #      minReplicas: 2 # defulat 1
-        
-
-
+  # - name: istio-egressgateway
+  #   resources:
+  #     requests_cpu: 1000m
+  #     requests_memory: 1024Mi
+  #     limits_cpu: 2000m
+  #     limits_memory: 2048Mi
+  #   hpaMaxReplicas: 10
+  #   hpaTargetCpuUtilization: 80

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -2,39 +2,49 @@ IstioOperator:
   enabled: true
   # Configuration profile is one of "default, demo, minimal, remote, empty, preview".
   # refer to https://istio.io/latest/docs/setup/additional-setup/config-profiles/
-  # profile: default 
-  istioNamespace: istio-namespace1
+  profile: default 
+  revision: "1-9-1"
+  istioNamespace: istio-system
   meshConfig:
     enableAccessLog: true
+    enablePrometheusMerge: true
     enableTracing: true
     # customTags:
     #   my_tag_literal:
     #     literal:
     #       value: test
-    sampling: 100
+    tracing_sampling: 100
+    tracing_url: jaeger-operator-jaeger-collector.lma.svc:9411
 
-  ingressGateways: []
-  #- name: istio-ingressgateway
-  #  enabled: true
-  #  # namespace: istio-namespace2
-  #  # label:
-  #  #   custom_label: custom_value
-  #  k8s:
-  #    resources:
-  #      requests:
-  #        cpu: 500m # default 500m
-  #        memory: 1024Mi # default 2048Mi
-  #      limits:
-  #        cpu: 1000m # default 500m
-  #        memory: 2048Mi # default 2048Mi
-  #    hpaSpec:
-  #      maxReplicas: 10 # default 5
-  #      minReplicas: 2 # defulat 1
-
+  ingressGateways:
+    # Default ingressGateway config #
+    - name: istio-ingressgateway
+      enabled: true
+      namespace: istio-gateway
+      k8s:
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 1024Mi
+          limits:
+            cpu: 2000m
+            memory: 2048Mi
+        hpaSpec:
+          maxReplicas: 10
+          minReplicas: 1
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-ingressgateway
   egressGateways: []
   #- name: istio-egressgateway
   #  enabled: true
-  #  # namespace: istio-namespace2 
+  #  # namespace: istio-gateway
   #  # label:
   #  #   custom_label: custom_value
   #  k8s:
@@ -51,4 +61,3 @@ IstioOperator:
         
 
 
-  tracing_url: jaeger-operator-jaeger-collector.lma.svc:9411

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -25,6 +25,7 @@ IstioOperator:
   #     limits_cpu: 2000m
   #     limits_memory: 2048Mi
   #   hpaMaxReplicas: 10
+  #   hpaMinReplicas: 2
   #   hpaTargetCpuUtilization: 80
   #   serviceType: NodePort
           
@@ -36,5 +37,6 @@ IstioOperator:
   #     limits_cpu: 2000m
   #     limits_memory: 2048Mi
   #   hpaMaxReplicas: 10
+  #   hpaMinReplicas: 2
   #   hpaTargetCpuUtilization: 80
   #   serviceType: NodePort

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -14,8 +14,8 @@ IstioOperator:
     #   my_tag_literal:
     #     literal:
     #       value: test
-    tracing_sampling: 100
-    tracing_url: jaeger-operator-jaeger-collector.lma.svc:9411
+    tracingSampling: 100
+    tracingUrl: jaeger-operator-jaeger-collector.lma.svc:9411
 
   ingressGateways: []
   # - name: istio-ingressgateway

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -26,6 +26,7 @@ IstioOperator:
   #     limits_memory: 2048Mi
   #   hpaMaxReplicas: 10
   #   hpaTargetCpuUtilization: 80
+  #   serviceType: NodePort
           
   egressGateways: []
   # - name: istio-egressgateway
@@ -36,3 +37,4 @@ IstioOperator:
   #     limits_memory: 2048Mi
   #   hpaMaxReplicas: 10
   #   hpaTargetCpuUtilization: 80
+  #   serviceType: NodePort


### PR DESCRIPTION
IsioOperator custom resource를 배포하기 위한 service-mesh chart update.

- ingressGateway를 default로 1개 배포하며, cpu metric 기반의 HPA spec을 포함하고 있음.
- namespace별 추가 gateway는 본 차트가 아니라 스크립트 등으로 따로 배포할 수 있도록 준비할 예정임 (chart에 포함하기로 변경함)