### PR TITLE
fix namespace of istio components

### DIFF
--- a/service-mesh-resource/Chart.yaml
+++ b/service-mesh-resource/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/service-mesh-resource/templates/istio-controlplane.yaml
+++ b/service-mesh-resource/templates/istio-controlplane.yaml
@@ -2,7 +2,7 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   name: istio-controlplane
 spec:
   revision: {{ .Values.IstioOperator.revision }}

--- a/service-mesh-resource/templates/istio-gateway.yaml
+++ b/service-mesh-resource/templates/istio-gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   name: istio-gateway
-  namespace: istio-gateway
+  namespace: {{ .Release.Namespace }}
 spec:
   revision: {{ .Values.IstioOperator.revision }}
   profile: empty

--- a/service-mesh-resource/templates/namespace.yaml
+++ b/service-mesh-resource/templates/namespace.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.createNamespace -}}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+{{- end -}}

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -1,3 +1,4 @@
+createNamespace: false
 IstioOperator:
   enableControlplane: true
   enableGateway: false


### PR DESCRIPTION
* istio-controlplane과 istio-gateway의 namespace를 release namespace로 변경
* release namespace가 아닌 static value면 사용자가 어디에 배포됐는지 찾기 어려움.
* istio gateway의 경우 `istio-gateway` namespace가 만들어지지 않기 때문에 배포시 에러 발생. 따라서 namespace를 만들 수 있도록 createNamespace 변수 추가.