### PR TITLE
Add istio prometheus rules

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project 
 name: lma-addons
-version: 1.4.0
+version: 1.5.0

--- a/lma-addons/templates/prometheus-rule/istio-metrics-aggregation.yaml
+++ b/lma-addons/templates/prometheus-rule/istio-metrics-aggregation.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.prometheusRules.istio.aggregation.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: istio-metric-aggregation
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: istio-prometheus
+    name: prometheus
+spec:
+  groups:
+  - name: "istio.metricsAggregation-rules"
+    interval: {{ .Values.prometheusRules.istio.aggregation.interval }}
+    rules:
+    - record: "workload:istio_requests_total"
+      expr: "sum without(instance, namespace, pod) (istio_requests_total)"
+
+    - record: "workload:istio_request_duration_milliseconds_count"
+      expr: "sum without(instance, namespace, pod) (istio_request_duration_milliseconds_count)"
+    - record: "workload:istio_request_duration_milliseconds_sum"
+      expr: "sum without(instance, namespace, pod) (istio_request_duration_milliseconds_sum)"
+    - record: "workload:istio_request_duration_milliseconds_bucket"
+      expr: "sum without(instance, namespace, pod) (istio_request_duration_milliseconds_bucket)"
+
+    - record: "workload:istio_request_bytes_count"
+      expr: "sum without(instance, namespace, pod) (istio_request_bytes_count)"
+    - record: "workload:istio_request_bytes_sum"
+      expr: "sum without(instance, namespace, pod) (istio_request_bytes_sum)"
+    - record: "workload:istio_request_bytes_bucket"
+      expr: "sum without(instance, namespace, pod) (istio_request_bytes_bucket)"
+
+    - record: "workload:istio_response_bytes_count"
+      expr: "sum without(instance, namespace, pod) (istio_response_bytes_count)"
+    - record: "workload:istio_response_bytes_sum"
+      expr: "sum without(instance, namespace, pod) (istio_response_bytes_sum)"
+    - record: "workload:istio_response_bytes_bucket"
+      expr: "sum without(instance, namespace, pod) (istio_response_bytes_bucket)"
+
+    - record: "workload:istio_tcp_connections_opened_total"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_connections_opened_total)"
+    - record: "workload:istio_tcp_connections_closed_total"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_connections_closed_total)"
+
+    - record: "workload:istio_tcp_sent_bytes_total_count"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_sent_bytes_total_count)"
+    - record: "workload:istio_tcp_sent_bytes_total_sum"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_sent_bytes_total_sum)"
+    - record: "workload:istio_tcp_sent_bytes_total_bucket"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_sent_bytes_total_bucket)"
+
+    - record: "workload:istio_tcp_received_bytes_total_count"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_received_bytes_total_count)"
+    - record: "workload:istio_tcp_received_bytes_total_sum"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_received_bytes_total_sum)"
+    - record: "workload:istio_tcp_received_bytes_total_bucket"
+      expr: "sum without(instance, namespace, pod) (istio_tcp_received_bytes_total_bucket)"
+{{- end }}

--- a/lma-addons/templates/prometheus-rule/istio-metrics-optimization.yaml
+++ b/lma-addons/templates/prometheus-rule/istio-metrics-optimization.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.prometheusRules.istio.optimization.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: istio-metrics-optimization
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: istio-prometheus
+    name: prometheus
+spec:
+  groups:
+  - name: "istio.recording-rules"
+    interval: {{ .Values.prometheusRules.istio.optimization.interval }}
+    rules:
+    - record: "istio:istio_requests:by_destination_service:rate1m"
+      expr: |
+        sum(irate(istio_requests_total{reporter="destination"}[1m]))
+        by (
+          destination_canonical_service,
+          destination_workload_namespace
+        )
+    - record: "istio:istio_request_duration_milliseconds_bucket:p95:rate1m"
+      expr: |
+        histogram_quantile(0.95,
+          sum(irate(istio_request_duration_milliseconds_bucket{reporter="source"}[1m]))
+          by (
+            destination_canonical_service,
+            destination_workload_namespace,
+            source_canonical_service,
+            source_workload_namespace,
+            le
+          )
+        )
+{{- end }}

--- a/lma-addons/values.yaml
+++ b/lma-addons/values.yaml
@@ -224,4 +224,11 @@ prometheusRules:
       kubelet: true
       mariadb: true
       rabbitmq: true
+  istio:
+    aggregation:
+      enabled: true
+      interval: "5s"
+    optimization:
+      enabled: true
+      interval: "5s"
 


### PR DESCRIPTION
prometheus rule 중에 istio metric 의 aggregation 와 optimization 을 추가하였음.
istio grafana 의 1.9.1 대시보드에 관련 모니터링이 이미 추가되어 있음. (기본 내용 완료)
고객별 요구사항에 맞춘 통계식의 대시보드는 aggregation 과 optimization rule 을 활용하여 추가할 수 있음.