### PR TITLE
add handler to support http/https on communication with objectstorage

### DIFF
--- a/thanos-config/templates/secret.yaml
+++ b/thanos-config/templates/secret.yaml
@@ -12,4 +12,5 @@ stringData:
       endpoint: {{ .Values.objectStorage.endpoint }}
       access_key: {{ .Values.objectStorage.access_key }}
       secret_key: {{ .Values.objectStorage.secret_key }}
+      insecure: {{ .Values.objectStorage.insecure }}
 {{- end }}

--- a/thanos-config/values.yaml
+++ b/thanos-config/values.yaml
@@ -5,6 +5,7 @@ objectStorage:
   endpoint: thanos-minio.fed.svc.cluster.local:9000
   access_key: taco
   secret_key: password
+  insecure: true
 
 sidecarsService:
   enabled: true


### PR DESCRIPTION
prometheus의 thanos sidecar에서 사용하는 object storage 연동에 http/https 조정