### PR TITLE
create dashboards when it's enabled

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project 
 name: lma-addons
-version: 1.4.0
+version: 1.5.0

--- a/lma-addons/templates/grafana-dashboard/dashboards/calico-status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/calico-status.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.kubernetes.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/ceph-cluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/ceph-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.ceph.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/cluster-resource.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/cluster-resource.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.kubernetes.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/cluster-status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/cluster-status.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.kubernetes.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/felix-dataplane.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/felix-dataplane.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.felixDataplane.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/hosts-status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/hosts-status.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.node.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/node-network.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/node-network.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.node.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/node-status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/node-status.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.node.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/openstack-service.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/openstack-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.openstack.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/osd-device-details.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/osd-device-details.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.ceph.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/osds-overview.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/osds-overview.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.ceph.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/pod-status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/pod-status.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.kubernetes.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/pool-detail.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/pool-detail.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.openstack.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/pool-overview.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/pool-overview.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.openstack.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/rbd-overview.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/rbd-overview.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.ceph.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-calicostatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-calicostatus.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-etcdcluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-etcdcluster.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-f5status.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-f5status.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.f5 }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-cluster.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-overview.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-overview.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-pods.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-kubernetes-pods.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-node-networks.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-node-networks.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-nodestatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-nodestatus.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/templates/grafana-dashboard/dashboards/taco-tridentstatus.yaml
+++ b/lma-addons/templates/grafana-dashboard/dashboards/taco-tridentstatus.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if and .Values.grafanaDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.enabled .Values.grafanaDashboard.tacoCustomDashboard.f5 }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lma-addons/values.yaml
+++ b/lma-addons/values.yaml
@@ -125,6 +125,19 @@ grafanaDashboard:
     enabled: false
   jaeger:
     enabled: false
+  tacoCustomDashboard:
+    enabled: false
+    f5: false
+  ceph:
+    enabled: false
+  felixDataplane:
+    enabled: false
+  kubernetes:
+    enabled: false
+  openstack:
+    enabled: false
+  node: 
+    enabled: false
 
 metricbeat:
   enabled: true


### PR DESCRIPTION
* grafana dashboard를 모두 만들지 않고 종류별로 구분해서 enabled / disabled 시킬 수 있도록 한다.
* ceph, kubernetes, node, openstack, taco custom 으로 분류