### PR TITLE
Fix service-mesh-resource chart

### DIFF
--- a/service-mesh-resource/templates/istio-controlplane.yaml
+++ b/service-mesh-resource/templates/istio-controlplane.yaml
@@ -31,4 +31,8 @@ spec:
   values:
     global:
       istioNamespace: {{ .Values.IstioOperator.istioNamespace }}
+  components:
+    ingressGateways:
+      - name: istio-ingressgateway
+        enabled: false
 {{- end }}

--- a/service-mesh-resource/templates/istio-gateway.yaml
+++ b/service-mesh-resource/templates/istio-gateway.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.IstioOperator.enableGateway }}
+{{- $gatewayNamespace := .Values.IstioOperator.gatewayNamespace }}
+---
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
@@ -13,7 +15,7 @@ spec:
 {{- range $gateway := .Values.IstioOperator.ingressGateways }}
       - name: istio-ingressgateway-{{- $gateway.name }}
         enabled: true
-        namespace: istio-gateway
+        namespace: {{ $gatewayNamespace }}
         label:
           istio: ingressgateway-{{- $gateway.name }}
         k8s:

--- a/service-mesh-resource/values.yaml
+++ b/service-mesh-resource/values.yaml
@@ -7,6 +7,7 @@ IstioOperator:
   profile: default 
   revision: "1-9-1"
   istioNamespace: istio-system
+  gatewayNamespace: istio-system
   meshConfig:
     enableAccessLog: true
     enablePrometheusMerge: true
@@ -19,7 +20,7 @@ IstioOperator:
     tracingUrl: jaeger-operator-jaeger-collector.lma.svc:9411
 
   ingressGateways: []
-  # - name: istio-ingressgateway
+  # - name: default
   #   resources:
   #     requests_cpu: 1000m
   #     requests_memory: 1024Mi


### PR DESCRIPTION
* service-mesh resource 중 controlplane 및 gateway가 별도의 CR로 확실히 분리되어 배포되도록 수정함. 
* gateway namespace를 변수화하여 필요시 수정 가능하게 함