### PR TITLE
support static nodeport for the thanos sidecar service

### DIFF
--- a/thanos-config/templates/service.yaml
+++ b/thanos-config/templates/service.yaml
@@ -9,6 +9,9 @@ spec:
   ports:
     - port: {{ .Values.sidecarsService.port }}
       targetPort: http
+{{- if and (eq .Values.sidecarsService.type "NodePort") .Values.sidecarsService.nodePort }}
+      nodePort: {{ .Values.sidecarsService.nodePort }}
+{{- end }}
       protocol: TCP
       name: grpc
 ---


### PR DESCRIPTION
thanos-sidecar에 노드포트를 지정하여 서비스를 만들수 있음