### PR TITLE
TACODEV-774: add service monitor for metrics of argo series

### DIFF
--- a/lma-addons/templates/service-monitor/argo-cd.yaml
+++ b/lma-addons/templates/service-monitor/argo-cd.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.argocd.enabled }}
+---
+apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitoring.coreos.com") }}
+kind: ServiceMonitor
+metadata:
+  name: argocd-application
+  namespace: lma
+  labels:
+    release: prometheus-operator
+spec:
+  jobLabel: argocd-application
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-metrics
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.argocd.interval }}
+    interval: {{ .Values.serviceMonitor.argocd.interval }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.serviceMonitor.argocd.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.argocd.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.argocd.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.argocd.relabelings | indent 6 }}
+{{- end }}
+---
+apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitoring.coreos.com") }}
+kind: ServiceMonitor
+metadata:
+  name: argocd-server
+  namespace: lma
+  labels:
+    release: prometheus-operator
+spec:
+  jobLabel: argocd-server
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-metrics
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.argocd.interval }}
+    interval: {{ .Values.serviceMonitor.argocd.interval }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.serviceMonitor.argocd.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.argocd.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.argocd.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.argocd.relabelings | indent 6 }}
+{{- end }}
+
+{{- end }}

--- a/lma-addons/templates/service-monitor/argo-workflow.yaml
+++ b/lma-addons/templates/service-monitor/argo-workflow.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.workflow.enabled }}
+---
+apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitoring.coreos.com") }}
+kind: ServiceMonitor
+metadata:
+  name: argo-workflows-server
+  namespace: lma
+  labels:
+    release: prometheus-operator
+spec:
+  jobLabel: argo-workflows-server
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-server
+  endpoints:
+  - port: http
+    {{- if .Values.serviceMonitor.workflow.interval }}
+    interval: {{ .Values.serviceMonitor.workflow.interval }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.serviceMonitor.workflow.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.workflow.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.workflow.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.workflow.relabelings | indent 6 }}
+{{- end }}
+---
+apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitoring.coreos.com") }}
+kind: ServiceMonitor
+metadata:
+  name: argo-workflows-controller
+  namespace: lma
+  labels:
+    release: prometheus-operator
+spec:
+  jobLabel: argo-workflows-controller
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-workflow-controller
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.workflow.interval }}
+    interval: {{ .Values.serviceMonitor.workflow.interval }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.serviceMonitor.workflow.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.workflow.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.workflow.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.workflow.relabelings | indent 6 }}
+{{- end }}
+
+{{- end }}

--- a/lma-addons/values.yaml
+++ b/lma-addons/values.yaml
@@ -58,6 +58,20 @@ serviceMonitor:
     metricRelabelings: []
     relabelings: []
 
+  argocd:
+    enabled: true
+    ### interval for scrape
+    #interval: "10s"
+    metricRelabelings: []
+    relabelings: []
+
+  workflow:
+    enabled: true
+    ### interval for scrape
+    #interval: "10s"
+    metricRelabelings: []
+    relabelings: []
+
   openstack:
     enabled: false
     interval: "30s"


### PR DESCRIPTION
Objective
Argo worflow/CD도 prometheus metric으로 수집할 수 있다. Argo worklfow/CD의 metric을 조사하고, Argo CD 의 주요 metric 수집한다.
argo cd/workflow exporter 존재함, 서비스 모니터 생성해서 prometheus로 데이터 저장 확인 (lma-addons)
grafana dashboard 까지 추가, 확인 (grafana labs에 있는 대시보드 활용)

Doing with this PR
argo에서 나오는 metric을 수집하기 위한 서비스 모니터 설치지원