### PR TITLE
rook-ceph-cluster: fix toolbox image

### DIFF
--- a/rook-ceph-cluster/templates/toolbox.yaml
+++ b/rook-ceph-cluster/templates/toolbox.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: rook-ceph-tools
-          image: {{ .Values.cluster.image.repository }}:{{ .Values.cluster.image.tag }}
+          image: {{ .Values.rook.image.repository }}:{{ .Values.rook.image.tag }}
           command: ["/tini"]
           args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent

--- a/rook-ceph-cluster/values.yaml
+++ b/rook-ceph-cluster/values.yaml
@@ -1,3 +1,8 @@
+rook:
+  image:
+    repository: rook/ceph
+    tag: v1.6.7
+
 cluster:
   image:
     repository: ceph/ceph


### PR DESCRIPTION
rook ceph toolbox 의 경우 Ceph 컨테이너 이미지가 아닌 Rook 컨테이너 이미지를 사용하기 때문에 별도로 지정할 수 있도록 수정했습니다.