### PR TITLE
add prepare-decopod-controller chart

### DIFF
--- a/prepare-decapod-controller/.helmignore
+++ b/prepare-decapod-controller/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/prepare-decapod-controller/Chart.yaml
+++ b/prepare-decapod-controller/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0.0"
+description: Chart for decapod-controller preparation such as DB secret creation
+name: prepare-decapod-controller
+version: 0.1.0

--- a/prepare-decapod-controller/README.md
+++ b/prepare-decapod-controller/README.md
@@ -1,0 +1,11 @@
+# Prepare-decapod-controller Chart
+
+This charts handle tasks for preparing decapod controllers. Currently, it only does one thing:
+* Create postgresql secret that is used by both postgresql and argo-workflow chart.
+
+The value 'postgres.secretName' is referenced by other charts as follows.
+* values.existingSecret (by postgresql chart)
+* values.persistence.userNameSecret & values.persistence.passwordSecret (by argo-workflows chart)
+
+More preparation tasks can be added to this chart later.
+

--- a/prepare-decapod-controller/templates/secret.yaml
+++ b/prepare-decapod-controller/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-postgres-config
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  postgresql-password:  {{ .Values.postgres.password | b64enc | quote }}
+  postgresql-username:  {{ .Values.postgres.username | b64enc | quote }}

--- a/prepare-decapod-controller/templates/secret.yaml
+++ b/prepare-decapod-controller/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argo-postgres-config
+  name: {{ .Values.postgres.secretName }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:

--- a/prepare-decapod-controller/values.yaml
+++ b/prepare-decapod-controller/values.yaml
@@ -1,0 +1,3 @@
+postgres:
+  username: postgres
+  password: tacopassword

--- a/prepare-decapod-controller/values.yaml
+++ b/prepare-decapod-controller/values.yaml
@@ -1,3 +1,4 @@
 postgres:
+  secretName: argo-postgres-config
   username: postgres
   password: tacopassword


### PR DESCRIPTION
argocd를 이용한 decapod bootstrap 과정에서 argo-wf 차트에 postgres 접속을 위한 secret 생성하는 부분이 빠져있으므로 해당 secret 생성 위해 차트 작성함. (postgres 차트에서 생성하는 secret은 포맷이 달라서 사용 불가함)
향후 추가로 필요한 작업들이 생길 때마다 본 차트에 추가할 예정임.