### PR TITLE
Add baseOS variable for kubernetes node's OS

### DIFF
--- a/cluster-api-aws/templates/aws-cluster.yaml
+++ b/cluster-api-aws/templates/aws-cluster.yaml
@@ -14,3 +14,6 @@ spec:
   bastion:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.cluster.baseOS }}
+  imageLookupBaseOS: {{ .Values.cluster.baseOS }}
+  {{- end }}

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -26,6 +26,10 @@ cluster:
   #   disableIngressRules: false
   #   allowedCIDRBlocks:
   #   - 0.0.0.0/0
+  # baseOS is the name of the base operating system to use for image lookup the
+  # AMI is not set. (default: "ubuntu-18.04")
+  # Available os options: "centos-7", "ubuntu-18.04", "ubuntu-20.04", "amazon-2"
+  # baseOS: ubuntu-18.04
 
 apiVersion:
   infrastructure: infrastructure.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
this is optional, default value is 'ubuntu-18.04'
Available os options: "centos-7", "ubuntu-18.04", "ubuntu-20.04", "amazon-2"