### PR TITLE
make tks-contract, tks-info, tks-cluster-lcm helm chart

### DIFF
--- a/tks-cluster-lcm/.helmignore
+++ b/tks-cluster-lcm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tks-cluster-lcm/Chart.yaml
+++ b/tks-cluster-lcm/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: tks-cluster-lcm
+description: A Helm chart for tks-cluster-lcm
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/tks-cluster-lcm/templates/NOTES.txt
+++ b/tks-cluster-lcm/templates/NOTES.txt
@@ -1,0 +1,7 @@
+tks-cluster-lcm
+{{- if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "tks-cluster-lcm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "tks-cluster-lcm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  gRPC Call => $SERVICE_IP:{{ .Values.service.port }}
+{{- end }}

--- a/tks-cluster-lcm/templates/_helpers.tpl
+++ b/tks-cluster-lcm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tks-cluster-lcm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tks-cluster-lcm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tks-cluster-lcm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tks-cluster-lcm.labels" -}}
+helm.sh/chart: {{ include "tks-cluster-lcm.chart" . }}
+{{ include "tks-cluster-lcm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tks-cluster-lcm.selectorLabels" -}}
+app.kubernetes.io/service: tks
+app.kubernetes.io/name: {{ include "tks-cluster-lcm.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tks-cluster-lcm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tks-cluster-lcm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tks-cluster-lcm/templates/deployment.yaml
+++ b/tks-cluster-lcm/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tks-cluster-lcm.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-cluster-lcm.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tks-cluster-lcm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tks-cluster-lcm.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tks-cluster-lcm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: tks-cluster-lcm
+              containerPort: {{ .Values.args.port }}
+              protocol: TCP
+          command:
+            - /app/server
+          args: [
+            "-port", "{{ .Values.args.port }}",
+            "-info-address", "{{ .Values.args.tksInfoAddress }}",
+            "-info-port", "{{ .Values.args.tksInfoPort }}"
+          ]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tks-cluster-lcm/templates/hpa.yaml
+++ b/tks-cluster-lcm/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tks-cluster-lcm.fullname" . }}
+  labels:
+    {{- include "tks-cluster-lcm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tks-cluster-lcm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/tks-cluster-lcm/templates/ingress.yaml
+++ b/tks-cluster-lcm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "tks-cluster-lcm.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "tks-cluster-lcm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/tks-cluster-lcm/templates/service.yaml
+++ b/tks-cluster-lcm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tks-cluster-lcm.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-cluster-lcm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.args.port }}
+      protocol: TCP
+  selector:
+    {{- include "tks-cluster-lcm.selectorLabels" . | nindent 4 }}

--- a/tks-cluster-lcm/templates/serviceaccount.yaml
+++ b/tks-cluster-lcm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tks-cluster-lcm.serviceAccountName" . }}
+  labels:
+    {{- include "tks-cluster-lcm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/tks-cluster-lcm/values.yaml
+++ b/tks-cluster-lcm/values.yaml
@@ -1,0 +1,74 @@
+replicaCount: 1
+
+namespace: tks
+
+image:
+  repository: docker.io/seungkyua/tks-cluster-lcm
+  pullPolicy: Always
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: "tks-cluster-lcm"
+fullnameOverride: "tks-cluster-lcm"
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: "tks-cluster-lcm"
+
+args:
+  port: 9110
+  tksInfoAddress: tks-info.tks.svc
+  tksInfoPort: 9110
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  port: 9110
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector:
+  taco-tks: enabled
+
+tolerations: []
+
+affinity: {}

--- a/tks-contract/.helmignore
+++ b/tks-contract/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tks-contract/Chart.yaml
+++ b/tks-contract/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: tks-contract
+description: A Helm chart for tks-contract
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/tks-contract/templates/NOTES.txt
+++ b/tks-contract/templates/NOTES.txt
@@ -1,0 +1,7 @@
+TKS-Contract
+{{- if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "tks-contract.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "tks-contract.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  gRPC Call => $SERVICE_IP:{{ .Values.service.port }}
+{{- end }}

--- a/tks-contract/templates/_helpers.tpl
+++ b/tks-contract/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tks-contract.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tks-contract.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tks-contract.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tks-contract.labels" -}}
+helm.sh/chart: {{ include "tks-contract.chart" . }}
+{{ include "tks-contract.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tks-contract.selectorLabels" -}}
+app.kubernetes.io/service: tks
+app.kubernetes.io/name: {{ include "tks-contract.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tks-contract.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tks-contract.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tks-contract/templates/deployment.yaml
+++ b/tks-contract/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tks-contract.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-contract.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tks-contract.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tks-contract.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tks-contract.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: tks-contract
+              containerPort: {{ .Values.args.port }}
+              protocol: TCP
+          command:
+            - /app/server
+          args: [
+            "-port", "{{ .Values.args.port }}",
+            "-dbhost", "{{ .Values.args.dbUrl }}",
+            "-dbport", "{{ .Values.args.dbPort }}",
+            "-dbuser", "{{ .Values.args.dbUser }}",
+            "-dbpassword", "{{ .Values.args.dbPassword }}",
+            "-info-address", "{{ .Values.args.tksInfoAddress }}",
+            "-info-port", "{{ .Values.args.tksInfoPort }}"
+          ]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tks-contract/templates/hpa.yaml
+++ b/tks-contract/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tks-contract.fullname" . }}
+  labels:
+    {{- include "tks-contract.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tks-contract.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/tks-contract/templates/ingress.yaml
+++ b/tks-contract/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "tks-contract.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "tks-contract.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/tks-contract/templates/pre-install-job.yaml
+++ b/tks-contract/templates/pre-install-job.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tks-contract.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-contract.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ include "tks-contract.fullname" . }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-install-job
+        image: "bitnami/postgresql:11.12.0-debian-10-r44"
+        env:
+        - name: DB_ADMIN_USER
+          value: {{ .Values.db.adminUser }}
+        - name: PGPASSWORD
+          value: {{ .Values.db.adminPassword }}
+        - name: DB_NAME
+          value: {{ .Values.db.dbName }}
+        - name: DB_USER
+          value: {{ .Values.args.dbUser }}
+        - name: DB_PASSWORD
+          value: {{ .Values.args.dbPassword }}
+        - name: DB_URL
+          value: {{ .Values.args.dbUrl }}
+        - name: DB_PORT
+          value: "{{ .Values.args.dbPort }}"
+        command:
+        - /bin/bash
+        - -c
+        - -x
+        - |
+          # check if ${DB_NAME} database already exists.
+          psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -lqt | cut -d \| -f 1 | grep -qw ${DB_NAME}
+          if [[ $? -ne 0 ]]; then
+            psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -c "CREATE DATABASE ${DB_NAME};"
+          fi
+
+          # check if ${DB_USER} user already exists.
+          psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -tc '\du' | cut -d \| -f 1 | grep -qw ${DB_USER}
+          if [[ $? -ne 0 ]]; then
+            psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -c "create user ${DB_USER} SUPERUSER password '${DB_PASSWORD}';"
+          fi
+
+          # check if contracts table in tks database already exists.
+          psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -d ${DB_NAME} -tc '\dt' | cut -d \| -f 2 | grep -qw contracts
+          if [[ $? -ne 0 ]]; then
+            echo """
+              \c ${DB_NAME};
+              CREATE TABLE contracts
+              (
+                  contractor_name character varying(50) COLLATE pg_catalog."default",
+                  id uuid primary key,
+                  available_services character varying(50)[] COLLATE pg_catalog."default",
+                  updated_at timestamp with time zone,
+                  created_at timestamp with time zone
+              );
+              CREATE UNIQUE INDEX idx_contractor_name ON contracts(contractor_name);
+              ALTER TABLE contracts CLUSTER ON idx_contractor_name;
+              INSERT INTO contracts(
+                contractor_name, id, available_services, updated_at, created_at)
+                VALUES ('tester', 'edcaa975-dde4-4c4d-94f7-36bc38fe7064', ARRAY['lma'], '2021-05-01'::timestamp, '2021-05-01'::timestamp);
+              
+              CREATE TABLE resource_quota
+              (
+                  id uuid primary key,
+                  cpu bigint,
+                  memory bigint,
+                  block bigint,
+                  block_ssd bigint,
+                  fs bigint,
+                  fs_ssd bigint,
+                  contract_id uuid,
+                  updated_at timestamp with time zone,
+                  created_at timestamp with time zone
+              );
+            """ | psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER}
+          fi

--- a/tks-contract/templates/service.yaml
+++ b/tks-contract/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tks-contract.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-contract.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.args.port }}
+      protocol: TCP
+  selector:
+    {{- include "tks-contract.selectorLabels" . | nindent 4 }}

--- a/tks-contract/templates/serviceaccount.yaml
+++ b/tks-contract/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tks-contract.serviceAccountName" . }}
+  labels:
+    {{- include "tks-contract.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/tks-contract/values.yaml
+++ b/tks-contract/values.yaml
@@ -1,0 +1,83 @@
+replicaCount: 1
+
+namespace: tks
+
+image:
+  repository: docker.io/seungkyua/tks-contract
+  pullPolicy: Always
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: "tks-contract"
+fullnameOverride: "tks-contract"
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: "tks-contract"
+
+args:
+  port: 9110
+  dbUrl: postgresql.decapod-db.svc
+  dbPort: 5432
+  dbUser: tksuser
+  dbPassword: tkspassword
+  tksInfoAddress: tks-info.tks.svc
+  tksInfoPort: 9110
+
+db:
+  adminUser: postgres
+  adminPassword: tacopassword
+  dbName: tks
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  port: 9110
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector:
+  taco-tks: enabled
+
+tolerations: []
+
+affinity: {}

--- a/tks-info/.helmignore
+++ b/tks-info/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tks-info/Chart.yaml
+++ b/tks-info/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: tks-info
+description: A Helm chart for tks-info
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/tks-info/templates/NOTES.txt
+++ b/tks-info/templates/NOTES.txt
@@ -1,0 +1,7 @@
+tks-info
+{{- if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "tks-info.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "tks-info.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  gRPC Call => $SERVICE_IP:{{ .Values.service.port }}
+{{- end }}

--- a/tks-info/templates/_helpers.tpl
+++ b/tks-info/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tks-info.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tks-info.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tks-info.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tks-info.labels" -}}
+helm.sh/chart: {{ include "tks-info.chart" . }}
+{{ include "tks-info.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tks-info.selectorLabels" -}}
+app.kubernetes.io/service: tks
+app.kubernetes.io/name: {{ include "tks-info.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tks-info.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tks-info.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tks-info/templates/deployment.yaml
+++ b/tks-info/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tks-info.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-info.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tks-info.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tks-info.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tks-info.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: tks-info
+              containerPort: {{ .Values.args.port }}
+              protocol: TCP
+          command:
+            - /app/server
+          args: [
+            "-port", "{{ .Values.args.port }}",
+            "-dbhost", "{{ .Values.args.dbUrl }}",
+            "-dbport", "{{ .Values.args.dbPort }}",
+            "-dbuser", "{{ .Values.args.dbUser }}",
+            "-dbpassword", "{{ .Values.args.dbPassword }}"
+          ]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tks-info/templates/hpa.yaml
+++ b/tks-info/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tks-info.fullname" . }}
+  labels:
+    {{- include "tks-info.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tks-info.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/tks-info/templates/ingress.yaml
+++ b/tks-info/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "tks-info.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "tks-info.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/tks-info/templates/pre-install-job.yaml
+++ b/tks-info/templates/pre-install-job.yaml
@@ -1,0 +1,107 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tks-info.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-info.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ include "tks-info.fullname" . }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-install-job
+        image: "bitnami/postgresql:11.12.0-debian-10-r44"
+        env:
+        - name: DB_ADMIN_USER
+          value: {{ .Values.db.adminUser }}
+        - name: PGPASSWORD
+          value: {{ .Values.db.adminPassword }}
+        - name: DB_NAME
+          value: {{ .Values.db.dbName }}
+        - name: DB_USER
+          value: {{ .Values.args.dbUser }}
+        - name: DB_PASSWORD
+          value: {{ .Values.args.dbPassword }}
+        - name: DB_URL
+          value: {{ .Values.args.dbUrl }}
+        - name: DB_PORT
+          value: "{{ .Values.args.dbPort }}"
+        command:
+        - /bin/bash
+        - -c
+        - -x
+        - |
+          # check if ${DB_NAME} database already exists.
+          psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -lqt | cut -d \| -f 1 | grep -qw ${DB_NAME}
+          if [[ $? -ne 0 ]]; then
+            psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -c "CREATE DATABASE ${DB_NAME};"
+          fi
+
+          # check if ${DB_USER} user already exists.
+          psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -tc '\du' | cut -d \| -f 1 | grep -qw ${DB_USER}
+          if [[ $? -ne 0 ]]; then
+            psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -c "create user ${DB_USER} SUPERUSER password '${DB_PASSWORD}';"
+          fi
+
+          # check if contracts table in tks database already exists.
+          psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER} -d ${DB_NAME} -tc '\dt' | cut -d \| -f 2 | grep -qw csp_infos
+          if [[ $? -ne 0 ]]; then
+            echo """
+              \c ${DB_NAME};
+              CREATE TABLE csp_infos
+              (
+                  id uuid primary key,
+                  contract_id uuid,
+                  name character varying(50) COLLATE pg_catalog."default",
+                  auth character varying(200) COLLATE pg_catalog."default",
+                  updated_at timestamp with time zone,
+                  created_at timestamp with time zone
+              );
+              CREATE TABLE clusters
+              (
+                  name character varying(50) COLLATE pg_catalog."default",
+                  id uuid primary key,
+                  contract_id uuid,
+                  csp_id uuid,
+                  status integer,
+                  master_flavor character varying(50) COLLATE pg_catalog."default",
+                  master_replicas integer,
+                  master_root_size bigint,
+                  worker_flavor character varying(50) COLLATE pg_catalog."default",
+                  worker_replicas integer,
+                  worker_root_size bigint,
+                  k8s_version character varying(50) COLLATE pg_catalog."default",
+                  kubeconfig character varying(1000) COLLATE pg_catalog."default",
+                  updated_at timestamp with time zone,
+                  created_at timestamp with time zone
+              );
+              CREATE TABLE application_groups
+              (
+                  name character varying(50) COLLATE pg_catalog."default",
+                  id uuid primary key,
+                  type bigint,
+                  status bigint,
+                  cluster_id uuid,
+                  external_label character varying(50) COLLATE pg_catalog."default",
+                  updated_at timestamp with time zone,
+                  created_at timestamp with time zone
+              );
+              CREATE TABLE applications
+              (
+                  id uuid primary key,
+                  type bigint,
+                  app_group_id uuid,
+                  endpoint character varying(200) COLLATE pg_catalog."default",
+                  metadata json,
+                  updated_at timestamp with time zone,
+                  created_at timestamp with time zone
+              );
+            """ | psql -h ${DB_URL} -p ${DB_PORT} -U ${DB_ADMIN_USER}
+          fi

--- a/tks-info/templates/service.yaml
+++ b/tks-info/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tks-info.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "tks-info.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.args.port }}
+      protocol: TCP
+  selector:
+    {{- include "tks-info.selectorLabels" . | nindent 4 }}

--- a/tks-info/templates/serviceaccount.yaml
+++ b/tks-info/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tks-info.serviceAccountName" . }}
+  labels:
+    {{- include "tks-info.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/tks-info/values.yaml
+++ b/tks-info/values.yaml
@@ -1,0 +1,81 @@
+replicaCount: 1
+
+namespace: tks
+
+image:
+  repository: docker.io/seungkyua/tks-info
+  pullPolicy: Always
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: "tks-info"
+fullnameOverride: "tks-info"
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: "tks-info"
+
+args:
+  port: 9110
+  dbUrl: postgresql.decapod-db.svc
+  dbPort: 5432
+  dbUser: tksuser
+  dbPassword: tkspassword
+
+db:
+  adminUser: postgres
+  adminPassword: tacopassword
+  dbName: tks
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  port: 9110
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector:
+  taco-tks: enabled
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
tks-contract 와 tks-info 는 helm pre-install hook 으로 db user, database, table 을 생성함.

사전조건
1. decapod-db 네임스페이스에 postgresql 이 설치되어 있어야 함
2. kubectl create ns tks (tks namespace 생성)
3. kubectl label node [노드명] taco-tks=enabled (노드 레이블 지정)

이후 tks 배포 workflow 를 만들어야 함.