### PR TITLE
Add prepare-etcd-secret chart

### DIFF
--- a/prepare-etcd-secret/.helmignore
+++ b/prepare-etcd-secret/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/prepare-etcd-secret/Chart.yaml
+++ b/prepare-etcd-secret/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: prepare-etcd-secret
+description: create etcd secret for prometheus
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/prepare-etcd-secret/templates/NOTES.txt
+++ b/prepare-etcd-secret/templates/NOTES.txt
@@ -1,0 +1,5 @@
+This helm chart create a etcd secret at master node.
+
+Secret Name: {{ include "prepare-etcd-secret.fullname" . }}
+Namespace: {{ .Release.Namespace }}
+

--- a/prepare-etcd-secret/templates/_helpers.tpl
+++ b/prepare-etcd-secret/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prepare-etcd-secret.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prepare-etcd-secret.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prepare-etcd-secret.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prepare-etcd-secret.labels" -}}
+helm.sh/chart: {{ include "prepare-etcd-secret.chart" . }}
+{{ include "prepare-etcd-secret.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prepare-etcd-secret.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prepare-etcd-secret.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prepare-etcd-secret.serviceAccountName" -}}
+{{- if .Values.rbac.create }}
+{{- default (include "prepare-etcd-secret.fullname" .) .Values.rbac.name }}
+{{- else }}
+{{- default "default" .Values.rbac.name }}
+{{- end }}
+{{- end }}

--- a/prepare-etcd-secret/templates/job-secret.yaml
+++ b/prepare-etcd-secret/templates/job-secret.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "prepare-etcd-secret.fullname" . }}
+spec:
+  template:
+    metadata:
+      name: {{ include "prepare-etcd-secret.fullname" . }}
+    spec:
+      serviceAccountName: {{ include "prepare-etcd-secret.serviceAccountName" . }}
+      containers:
+      - name: hyperkube
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          kubectl create secret generic etcd-client-cert \
+          --from-file=etcd-ca=/ssl/{{ .Values.etcd.certfile }} \
+          --from-file=etcd-client=/ssl/{{ .Values.etcd.client_certfile }} \
+          --from-file=etcd-client-key=/ssl/{{ .Values.etcd.client_keyfile }} \
+          --namespace {{ .Release.Namespace }}
+        volumeMounts:
+        - name: ssldir
+          mountPath: /ssl
+      volumes:
+      - name: ssldir
+        hostPath:
+          path: {{ .Values.etcd.certdir }}
+          type: Directory
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure

--- a/prepare-etcd-secret/templates/job-secret.yaml
+++ b/prepare-etcd-secret/templates/job-secret.yaml
@@ -33,4 +33,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      tolerations:
+      {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       restartPolicy: OnFailure

--- a/prepare-etcd-secret/templates/rbac.yaml
+++ b/prepare-etcd-secret/templates/rbac.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prepare-etcd-secret.serviceAccountName" . }}
+  labels:
+    {{- include "prepare-etcd-secret.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "prepare-etcd-secret.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "prepare-etcd-secret.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prepare-etcd-secret.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "prepare-etcd-secret.serviceAccountName" . }}
+{{- end }}

--- a/prepare-etcd-secret/values.yaml
+++ b/prepare-etcd-secret/values.yaml
@@ -1,0 +1,29 @@
+# Default values for prepare-etcd-secret.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+etcd:
+  certdir: /etc/kubernetes/pki/etcd
+  certfile: ca.crt
+  client_certfile: peer.crt 
+  client_keyfile: peer.key
+
+image:
+  repository: k8s.gcr.io/hyperkube
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v1.18.8"
+
+nameOverride: ""
+fullnameOverride: ""
+
+rbac:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+nodeSelector: 
+  "node-role.kubernetes.io/master": ""

--- a/prepare-etcd-secret/values.yaml
+++ b/prepare-etcd-secret/values.yaml
@@ -27,3 +27,7 @@ rbac:
 
 nodeSelector: 
   "node-role.kubernetes.io/master": ""
+tolerations:
+- key: "node-role.kubernetes.io/master"
+  effect: "NoSchedule"
+  operator: "Exists"


### PR DESCRIPTION
lma 배포 시 prometheus에서 etcd-cert-secret을 찾지 못하는 에러를 해결하기 위한 차트입니다.
(https://tde.sktelecom.com/pms/browse/TACODEV-920)
이 차트를 배포하면 마스터 노드 중 한 곳에 Job이 실행되고, 마스터 노드의 etcd cert를 이용해 etcd-cert-secret을 생성합니다.
Value파일에서 다음 부분을 환경에 맞게 수정해야합니다. default value의 경우 AWS에 배포된 마스터 노드의 etcd cert정보를 참고하였습니다.

마스터 노드에서 실행하기 위해 Values.nodeSelector에 적절한 값을 입력해야합니다.
```
nodeSelector: 
  "node-role.kubernetes.io/master": ""
```
또한 마스터 노드에서 etcd cert의 위치와 파일이름을 환경에 맞게 입력해야합니다.
```
etcd:
  certdir: /etc/kubernetes/pki/etcd
  certfile: ca.crt
  client_certfile: peer.crt 
  client_keyfile: peer.key
```