### PR TITLE
Add an initContainer that fixes the kernel setting

### DIFF
--- a/eck-resource/Chart.yaml
+++ b/eck-resource/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploy resources of eck operator
 name: eck-resource
-version: 1.1.0
+version: 1.1.1

--- a/eck-resource/templates/elasticsearch.yaml
+++ b/eck-resource/templates/elasticsearch.yaml
@@ -22,6 +22,11 @@ spec:
   {{- toYaml $node.config | nindent 6 }}
     podTemplate:
       spec:
+        initContainers:
+        - name: sysctl
+          securityContext:
+            privileged: true
+          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
         containers:
         - name: elasticsearch
           resources:


### PR DESCRIPTION
elasticsearch 사용 시 필요한 호스트 커널 파라미터를 initContainer에 추가하여 설정하는 PR입니다.
(https://tde.sktelecom.com/pms/browse/TACODEV-920)

아래 사이트 참고)
https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html