### PR TITLE
Fix default value for decapod

### DIFF
--- a/prepare-etcd-secret/Chart.yaml
+++ b/prepare-etcd-secret/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/prepare-etcd-secret/templates/job-secret.yaml
+++ b/prepare-etcd-secret/templates/job-secret.yaml
@@ -33,8 +33,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      tolerations:
       {{- with .Values.tolerations }}
+      tolerations:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       restartPolicy: OnFailure

--- a/prepare-etcd-secret/values.yaml
+++ b/prepare-etcd-secret/values.yaml
@@ -25,9 +25,9 @@ rbac:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-nodeSelector: 
-  "node-role.kubernetes.io/master": ""
-tolerations:
-- key: "node-role.kubernetes.io/master"
-  effect: "NoSchedule"
-  operator: "Exists"
+nodeSelector: {} 
+  #"node-role.kubernetes.io/master": ""
+tolerations: []
+  #- key: "node-role.kubernetes.io/master"
+  #  effect: "NoSchedule"
+  #  operator: "Exists"


### PR DESCRIPTION
- Decapod에서 override시 충돌되지 않도록, nodeSelector와 tolerartion의 기본값을 공란으로 변경하였습니다.
- Changed the default value to not specify anything so that decapod can
  modify the value.