### PR TITLE
rook-ceph-cluster: add placment options for Ceph services

### DIFF
--- a/rook-ceph-cluster/templates/cluster.yaml
+++ b/rook-ceph-cluster/templates/cluster.yaml
@@ -117,34 +117,10 @@ spec:
     # allowUninstallWithVolumes defines how the uninstall should be performed
     # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
     allowUninstallWithVolumes: false
-  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
-  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
-  # tolerate taints with a key of 'storage-node'.
-#  placement:
-#    all:
-#      nodeAffinity:
-#        requiredDuringSchedulingIgnoredDuringExecution:
-#          nodeSelectorTerms:
-#          - matchExpressions:
-#            - key: role
-#              operator: In
-#              values:
-#              - storage-node
-#      podAffinity:
-#      podAntiAffinity:
-#      topologySpreadConstraints:
-#      tolerations:
-#      - key: storage-node
-#        operator: Exists
-# The above placement information can also be specified for mon, osd, and mgr components
-#    mon:
-# Monitor deployments may contain an anti-affinity rule for avoiding monitor
-# collocation on the same node. This is a required rule when host network is used
-# or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
-# preferred rule with weight: 50.
-#    osd:
-#    mgr:
-#    cleanup:
+  {{- if .Values.cluster.placement }}
+  placement:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
 #    all:
 #    mon:

--- a/rook-ceph-cluster/values.yaml
+++ b/rook-ceph-cluster/values.yaml
@@ -19,6 +19,22 @@ cluster:
     enabled: false
   network:
     hostNetworkingEnabled: false
+  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
+  # tolerate taints with a key of 'storage-node'.
+#   placement:
+#    all:
+#      nodeAffinity:
+#        requiredDuringSchedulingIgnoredDuringExecution:
+#          nodeSelectorTerms:
+#          - matchExpressions:
+#            - key: role
+#              operator: In
+#              values:
+#              - storage-node
+#      tolerations:
+#      - key: storage-node
+#        operator: Exists
   crashCollector:
     enabled: true
 block_pools:


### PR DESCRIPTION
rook-ceph 클러스터의 서비스 데몬들 (mon, mgr, osd)을 특정 노드에 스케쥴링 하기 위한 옵션 추가입니다.

values.yaml 예제는 해당 노드가 Ceph을 위해서만 사용되기 위해 1) 'role=storage-node' 레이블이 있는 노드로, 2) storage-node 노드 테인트를 허용하는 내용으로 되어 있습니다.