### PR TITLE
rook: fix wrong scope in CephCluster template

### DIFF
--- a/rook-ceph-cluster/templates/cluster.yaml
+++ b/rook-ceph-cluster/templates/cluster.yaml
@@ -117,7 +117,7 @@ spec:
     # allowUninstallWithVolumes defines how the uninstall should be performed
     # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
     allowUninstallWithVolumes: false
-  {{- if .Values.cluster.placement }}
+  {{- with .Values.cluster.placement }}
   placement:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/rook-ceph-cluster/values.yaml
+++ b/rook-ceph-cluster/values.yaml
@@ -22,7 +22,7 @@ cluster:
   # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
   # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
   # tolerate taints with a key of 'storage-node'.
-#   placement:
+  placement: {}
 #    all:
 #      nodeAffinity:
 #        requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Values.cluster.placement 구문 scope 처리 오류를 수정하였습니다.