### PR TITLE
fix grafana dashboard for istio

### DIFF
--- a/servicemesh-grafana-dashboard/templates/istio-control-plane.yaml
+++ b/servicemesh-grafana-dashboard/templates/istio-control-plane.yaml
@@ -11,42 +11,6 @@ metadata:
 data:
   istio-control-plane-dashboard.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "6.4.3"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "table",
-          "name": "Table",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -84,7 +48,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 5,
@@ -182,7 +146,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -334,7 +298,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -437,7 +401,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -531,7 +495,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -630,7 +594,7 @@ data:
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "description": "Shows the rate of pilot pushes",
           "fill": 1,
           "gridPos": {
@@ -752,7 +716,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "description": "Captures a variety of pilot errors",
           "fill": 1,
           "gridPos": {
@@ -903,7 +867,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "description": "Shows the total time it takes to push a config update to a proxy",
           "fill": 1,
           "gridPos": {
@@ -1010,7 +974,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -1122,7 +1086,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -1234,7 +1198,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "description": "Shows details about Envoy proxies in the mesh",
           "fill": 1,
           "gridPos": {
@@ -1336,7 +1300,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -1422,7 +1386,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "description": "Shows the size of XDS requests and responses",
           "fill": 1,
           "gridPos": {
@@ -1739,29 +1703,6 @@ data:
       "schemaVersion": 18,
       "style": "dark",
       "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": true,
-              "text": "default",
-              "value": "default"
-            },
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "queryValue": "",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "type": "datasource"
-          }
-        ]
-      },
       "time": {
         "from": "now-5m",
         "to": "now"

--- a/servicemesh-grafana-dashboard/templates/istio-mesh.yaml
+++ b/servicemesh-grafana-dashboard/templates/istio-mesh.yaml
@@ -11,42 +11,6 @@ metadata:
 data:
   istio-mesh-dashboard.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "6.4.3"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "table",
-          "name": "Table",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -95,7 +59,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "ops",
           "gauge": {
             "maxValue": 100,
@@ -189,7 +153,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "percentunit",
           "gauge": {
             "maxValue": 100,
@@ -284,7 +248,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "ops",
           "gauge": {
             "maxValue": 100,
@@ -379,7 +343,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "ops",
           "gauge": {
             "maxValue": 100,
@@ -474,7 +438,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -570,7 +534,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -666,7 +630,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -762,7 +726,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -858,7 +822,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -954,7 +918,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1050,7 +1014,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1146,7 +1110,7 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1235,7 +1199,7 @@ data:
         },
         {
           "columns": [],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fontSize": "100%",
           "gridPos": {
             "h": 21,
@@ -1477,7 +1441,7 @@ data:
         },
         {
           "columns": [],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fontSize": "100%",
           "gridPos": {
             "h": 18,
@@ -1647,7 +1611,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 9,
@@ -1734,29 +1698,6 @@ data:
       "schemaVersion": 18,
       "style": "dark",
       "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": true,
-              "text": "default",
-              "value": "default"
-            },
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "queryValue": "",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "type": "datasource"
-          }
-        ]
-      },
       "time": {
         "from": "now-5m",
         "to": "now"

--- a/servicemesh-grafana-dashboard/templates/istio-performance.yaml
+++ b/servicemesh-grafana-dashboard/templates/istio-performance.yaml
@@ -11,42 +11,6 @@ metadata:
 data:
   istio-performance-dashboard.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "6.4.3"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "table",
-          "name": "Table",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -115,7 +79,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -208,7 +172,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -313,7 +277,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -405,7 +369,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -510,7 +474,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -608,7 +572,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -695,7 +659,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -782,7 +746,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -882,7 +846,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -1036,7 +1000,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -1141,7 +1105,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -1238,7 +1202,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "Prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,

--- a/servicemesh-grafana-dashboard/templates/istio-service.yaml
+++ b/servicemesh-grafana-dashboard/templates/istio-service.yaml
@@ -11,42 +11,6 @@ metadata:
 data:
   istio-service-dashboard.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "6.4.3"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "table",
-          "name": "Table",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -112,7 +76,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -213,7 +177,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "decimals": null,
               "fieldConfig": {
                 "defaults": {
@@ -310,7 +274,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -429,7 +393,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "#d44a3a"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -531,7 +495,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -632,7 +596,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "decimals": null,
               "fieldConfig": {
                 "defaults": {
@@ -729,7 +693,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -848,7 +812,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "#d44a3a"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -986,7 +950,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1093,7 +1057,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1200,7 +1164,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -1364,7 +1328,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1526,7 +1490,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1688,7 +1652,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1792,7 +1756,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1935,7 +1899,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2042,7 +2006,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2149,7 +2113,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -2313,7 +2277,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2475,7 +2439,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2637,7 +2601,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2742,7 +2706,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2849,165 +2813,6 @@ data:
       "schemaVersion": 26,
       "style": "dark",
       "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": true,
-              "text": "default",
-              "value": "default"
-            },
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "queryValue": "",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "type": "datasource"
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Service",
-            "multi": false,
-            "name": "service",
-            "options": [],
-            "query": "label_values(destination_service)",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": true,
-              "text": "destination",
-              "value": "destination"
-            },
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Reporter",
-            "multi": true,
-            "name": "qrep",
-            "options": [],
-            "query": "label_values(reporter)",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Client Workload Namespace",
-            "multi": true,
-            "name": "srcns",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total{reporter=\"$qrep\", destination_service=\"$service\"}) by (source_workload_namespace) or sum(istio_tcp_sent_bytes_total{reporter=\"$qrep\", destination_service=~\"$service\"}) by (source_workload_namespace))",
-            "refresh": 1,
-            "regex": "/.*namespace=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Client Workload",
-            "multi": true,
-            "name": "srcwl",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total{reporter=\"$qrep\", destination_service=~\"$service\", source_workload_namespace=~\"$srcns\"}) by (source_workload) or sum(istio_tcp_sent_bytes_total{reporter=\"$qrep\", destination_service=~\"$service\", source_workload_namespace=~\"$srcns\"}) by (source_workload))",
-            "refresh": 1,
-            "regex": "/.*workload=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 3,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Service Workload Namespace",
-            "multi": true,
-            "name": "dstns",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total{reporter=\"destination\", destination_service=\"$service\"}) by (destination_workload_namespace) or sum(istio_tcp_sent_bytes_total{reporter=\"destination\", destination_service=~\"$service\"}) by (destination_workload_namespace))",
-            "refresh": 1,
-            "regex": "/.*namespace=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Service Workload",
-            "multi": true,
-            "name": "dstwl",
-            "options": [],
-            "query": "query_result( sum(istio_requests_total{reporter=\"destination\", destination_service=~\"$service\", destination_workload_namespace=~\"$dstns\"}) by (destination_workload) or sum(istio_tcp_sent_bytes_total{reporter=\"destination\", destination_service=~\"$service\", destination_workload_namespace=~\"$dstns\"}) by (destination_workload))",
-            "refresh": 1,
-            "regex": "/.*workload=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 3,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          }
-        ]
-      },
       "time": {
         "from": "now-5m",
         "to": "now"

--- a/servicemesh-grafana-dashboard/templates/istio-workload.yaml
+++ b/servicemesh-grafana-dashboard/templates/istio-workload.yaml
@@ -11,42 +11,6 @@ metadata:
 data:
   istio-workload-dashboard.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "6.4.3"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "table",
-          "name": "Table",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -112,7 +76,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -213,7 +177,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "decimals": null,
               "fieldConfig": {
                 "defaults": {
@@ -310,7 +274,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -429,7 +393,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "#d44a3a"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -531,7 +495,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "#d44a3a"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -669,7 +633,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -776,7 +740,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -883,7 +847,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -1047,7 +1011,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1209,7 +1173,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1371,7 +1335,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1475,7 +1439,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1618,7 +1582,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1725,7 +1689,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -1832,7 +1796,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -1996,7 +1960,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2158,7 +2122,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2320,7 +2284,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2423,7 +2387,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "Prometheus",
               "fieldConfig": {
                 "defaults": {
                   "custom": {}
@@ -2530,165 +2494,6 @@ data:
       "schemaVersion": 26,
       "style": "dark",
       "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": true,
-              "text": "default",
-              "value": "default"
-            },
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "queryValue": "",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "type": "datasource"
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Namespace",
-            "multi": false,
-            "name": "namespace",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total) by (destination_workload_namespace) or sum(istio_tcp_sent_bytes_total) by (destination_workload_namespace))",
-            "refresh": 1,
-            "regex": "/.*_namespace=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Workload",
-            "multi": false,
-            "name": "workload",
-            "options": [],
-            "query": "query_result((sum(istio_requests_total{destination_workload_namespace=~\"$namespace\"}) by (destination_workload) or sum(istio_requests_total{source_workload_namespace=~\"$namespace\"}) by (source_workload)) or (sum(istio_tcp_sent_bytes_total{destination_workload_namespace=~\"$namespace\"}) by (destination_workload) or sum(istio_tcp_sent_bytes_total{source_workload_namespace=~\"$namespace\"}) by (source_workload)))",
-            "refresh": 1,
-            "regex": "/.*workload=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": true,
-              "text": "destination",
-              "value": "destination"
-            },
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Reporter",
-            "multi": true,
-            "name": "qrep",
-            "options": [],
-            "query": "label_values(reporter)",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Inbound Workload Namespace",
-            "multi": true,
-            "name": "srcns",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total{reporter=\"$qrep\", destination_workload=\"$workload\", destination_workload_namespace=~\"$namespace\"}) by (source_workload_namespace) or sum(istio_tcp_sent_bytes_total{reporter=\"$qrep\", destination_workload=\"$workload\", destination_workload_namespace=~\"$namespace\"}) by (source_workload_namespace))",
-            "refresh": 1,
-            "regex": "/.*namespace=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Inbound Workload",
-            "multi": true,
-            "name": "srcwl",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total{reporter=\"$qrep\", destination_workload=\"$workload\", destination_workload_namespace=~\"$namespace\", source_workload_namespace=~\"$srcns\"}) by (source_workload) or sum(istio_tcp_sent_bytes_total{reporter=\"$qrep\", destination_workload=\"$workload\", destination_workload_namespace=~\"$namespace\", source_workload_namespace=~\"$srcns\"}) by (source_workload))",
-            "refresh": 1,
-            "regex": "/.*workload=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 3,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "definition": "",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Destination Service",
-            "multi": true,
-            "name": "dstsvc",
-            "options": [],
-            "query": "query_result(sum(istio_requests_total{reporter=\"source\", source_workload=~\"$workload\", source_workload_namespace=~\"$namespace\"}) by (destination_service) or sum(istio_tcp_sent_bytes_total{reporter=\"source\", source_workload=~\"$workload\", source_workload_namespace=~\"$namespace\"}) by (destination_service))",
-            "refresh": 1,
-            "regex": "/.*destination_service=\"([^\"]*).*/",
-            "skipUrlSync": false,
-            "sort": 4,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          }
-        ]
-      },
       "time": {
         "from": "now-5m",
         "to": "now"

--- a/servicemesh-istio-resource/templates/istio-gateway.yaml
+++ b/servicemesh-istio-resource/templates/istio-gateway.yaml
@@ -53,6 +53,9 @@ spec:
           - name: status-port
             port: 15021
             targetPort: 15021
+            {{- if eq .Values.IstioOperator.components.ingressGateways.k8s.service.type "NodePort" }}
+            nodePort: {{ .Values.IstioOperator.components.ingressGateways.k8s.service.ports.statusNodePort }}
+            {{- end }}
           - name: http2
             port: 80
             targetPort: 8080

--- a/servicemesh-istio-resource/values.yaml
+++ b/servicemesh-istio-resource/values.yaml
@@ -64,7 +64,8 @@ IstioOperator:
         service:
           type: NodePort
           ports:
-            httpNodePort: 31081
+            statusNodePort: 31021
+            httpNodePort: 31080
             httpsNodePort: 31443
     egressGateways:
       enabled: false

--- a/servicemesh-jaeger-resource/templates/jaeger-controlplane.yaml
+++ b/servicemesh-jaeger-resource/templates/jaeger-controlplane.yaml
@@ -34,6 +34,9 @@ spec:
         password: {{ .Values.storage.options.es.password }}
         tls.ca: {{ .Values.storage.options.es.tlsCa }}
         server-urls: {{ .Values.storage.options.es.serverUrls }}
+  query:
+    options:
+      query.base-path: {{ .Values.query.basePath }}
   volumeMounts:
   - mountPath: /etc/ssl/certs
     name: es-tls

--- a/servicemesh-jaeger-resource/values.yaml
+++ b/servicemesh-jaeger-resource/values.yaml
@@ -25,7 +25,8 @@ storage:
       tlsCa: /etc/ssl/certs/tls.crt
       serverUrls: https://eck-elasticsearch-es-http.elastic-system.svc:9200
       secretName: 
-
+query:
+  basePath: /
 JaegerIngress:
   enabled: true
   namespace: istio-system


### PR DESCRIPTION
1. istio 용 grafana dashboard (v1.10.2) 에서 datasource 를 선택 오류 수정
2. ELB 와 istio gateway 를 연동하기 위해 gateway health check 용 nodeport 를 지정할 수 있게 수정
3. jaeger 를 ingress 로 접속할 때 base path (root url) 을 지정할 수 있게 수정

오류 수정이고 현재 버전에 모두 적용되어야 하므로 chart 버전을 올리지 않았음.