### PR TITLE
add dedicated es user for fluentbit

### DIFF
--- a/fluentbit-operator/Chart.yaml
+++ b/fluentbit-operator/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
   email: usnexp@gmail.com
 sources:
 - https://github.com/intelliguy/fluentbit-operator
-version: 1.0.10
+version: 1.1.0

--- a/fluentbit-operator/templates/_helpers.tpl
+++ b/fluentbit-operator/templates/_helpers.tpl
@@ -117,14 +117,13 @@ spec:
     httpUser:
       valueFrom:
         secretKeyRef:
-          name: {{ template "fluentbit-operator.fullname" $envAll }}-es-secret
+          name: {{ $envAll.Values.fluentbit.outputs.es.username }}-es-secret
           key: username
     httpPassword:
       valueFrom:
         secretKeyRef:
-          name: {{ template "fluentbit-operator.fullname" $envAll  }}-es-secret
+          name: {{ $envAll.Values.fluentbit.outputs.es.username }}-es-secret
           key: password
     tls:
       verify: false
-
 {{- end -}}

--- a/fluentbit-operator/templates/fluentbit/cm-cr.yaml
+++ b/fluentbit-operator/templates/fluentbit/cm-cr.yaml
@@ -1,57 +1,53 @@
-{{- if .Values.fluentbit.esTemplate.enabled }}
+{{- if or .Values.fluentbit.outputs.es.template.enabled .Values.fluentbit.outputs.es.enabled }}
 {{- $envAll := . }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fluentbit-operator.name" . }}-cr-cm
+  name: {{ $.Release.Name }}-cr-cm
   namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-weight": "2"
   labels:
     app: {{ template "fluentbit-operator.name" . }}-operator
 {{ include "fluentbit-operator.labels" . | indent 4 }}
 data:
   create_template.sh: |-
     #!/bin/sh
-    set -ev
+    set -ex
 
-{{ range .Values.fluentbit.esTemplate.ilms }}
+{{ range .Values.fluentbit.outputs.es.template.ilms }}
     echo "trying to setting policy {{.name}}..."
-    curl -k -u ${ES_USER}:${ES_PW} \
-      -X PUT "${ES_URL}/_ilm/policy/{{.name}}" \
+    curl -k -u elastic:${ELASTIC_PW} -X PUT "${ES_URL}/_ilm/policy/{{.name}}" \
       -H 'Content-Type:application/json' -H 'kbn-xsrf:true' -d @/tmp/ilm-{{.name}}.json
 {{- end}}
 
-{{ range .Values.fluentbit.esTemplate.templates }}
+{{ range .Values.fluentbit.outputs.es.template.templates }}
     echo "trying to setting Template {{.name}}..."
-    curl -k -u ${ES_USER}:${ES_PW} \
-      -X PUT "${ES_URL}/_template/{{.name}}" \
+    curl -k -u elastic:${ELASTIC_PW} -X PUT "${ES_URL}/_template/{{.name}}" \
       -H 'Content-Type:application/json' -H 'kbn-xsrf:true' -d @/tmp/template-{{.name}}.json
 {{- end}}
 
 {{ range .Values.fluentbit.targetLogs }}
   {{ if .index}}
     echo "trying to create initial index {{.index}}-000001..."
-    curl -k -u ${ES_USER}:${ES_PW} \
-      -X PUT "${ES_URL}/{{.index}}-000001" \
+    curl -k -u elastic:${ELASTIC_PW} -X PUT "${ES_URL}/{{.index}}-000001" \
       -H 'Content-Type:application/json' -H 'kbn-xsrf:true' -d @/tmp/index-{{.index}}.json
   {{- end }}
   {{ range .multi_index}}
     echo "trying to create initial index {{.index}}-000001..."
-    curl -k -u ${ES_USER}:${ES_PW} \
-      -X PUT "${ES_URL}/{{.index}}-000001" \
+    curl -k -u elastic:${ELASTIC_PW} -X PUT "${ES_URL}/{{.index}}-000001" \
       -H 'Content-Type:application/json' -H 'kbn-xsrf:true' -d @/tmp/index-{{.index}}.json
   {{- end }}
 {{- end }}
 
-{{ range .Values.fluentbit.esTemplate.ilms }}
+{{ range .Values.fluentbit.outputs.es.template.ilms }}
   ilm-{{ .name }}.json: |- 
     {{ toJson .json }}
 {{- end }}
 
-{{ range .Values.fluentbit.esTemplate.templates }}
+{{ range .Values.fluentbit.outputs.es.template.templates }}
   template-{{ .name }}.json: |-
     {{ toJson .json }}
 {{- end }}
@@ -79,4 +75,22 @@ data:
     }
   {{- end }}
 {{- end }}
+
+{{- if .Values.fluentbit.outputs.es.enabled }}
+  create_user.sh: |-
+    #!/bin/sh
+    set -ex
+    curl -k -u elastic:${ELASTIC_PW} -X POST ${ES_URL}/_security/user/$1 -H 'Content-Type: application/json' -d'
+    {
+      "password" : {{ .Values.fluentbit.outputs.es.password | quote }},
+      "roles" : [ "superuser" ],
+      "full_name" : "LMA user by TACO",
+      "email" : "taco@taco.com",
+      "metadata" : {
+        "intelligence" : 7
+      }
+    }
+    '
+{{- end}}
+
 {{- end}}

--- a/fluentbit-operator/templates/fluentbit/job-create-user.yaml
+++ b/fluentbit-operator/templates/fluentbit/job-create-user.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.fluentbit.enabled .Values.fluentbit.outputs.es.enabled .Values.fluentbit.outputs.es.createuser }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Release.Name }}-es-user
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "fluentbit-operator.name" . }}
+spec:
+  template:
+    metadata:
+      name: {{ $.Release.Name }}-es-template
+      labels:
+        app: {{ template "fluentbit-operator.name" . }}
+{{ include "fluentbit-operator.labels" . | indent 8 }}
+    spec:
+{{- if .Values.fluentbit.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.fluentbit.nodeSelector | indent 8 }}
+{{- end}}
+      containers:
+      - name: esuser
+        image: "{{ .Values.image.elasticsearchTemplates.repository }}:{{ .Values.image.elasticsearchTemplates.tag }}"
+        imagePullPolicy: "{{ .Values.image.elasticsearchTemplates.pullPolicy }}"
+        env:
+        - name: ES_URL
+          value: https://{{.Values.fluentbit.outputs.es.host}}:{{.Values.fluentbit.outputs.es.port}}
+        - name: ELASTIC_PW
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.fluentbit.outputs.es.elasticPasswordSecret  }}
+              key: elastic
+        command:
+        - timeout
+        - 5m
+        - /tmp/create_user.sh
+        - {{ .Values.fluentbit.outputs.es.username }}
+        - {{ .Values.fluentbit.outputs.es.password }}
+        volumeMounts:
+        - name: {{ $.Release.Name }}-cr-cm
+          mountPath: /tmp/create_user.sh
+          subPath: create_user.sh
+          readOnly: true
+      volumes:
+      - name: {{ $.Release.Name }}-cr-cm
+        configMap:
+          name: {{ $.Release.Name }}-cr-cm
+          defaultMode: 0777
+      restartPolicy: OnFailure
+{{- end}}

--- a/fluentbit-operator/templates/fluentbit/job-es-template.yaml
+++ b/fluentbit-operator/templates/fluentbit/job-es-template.yaml
@@ -1,24 +1,24 @@
-{{- if and .Values.fluentbit.enabled .Values.fluentbit.esTemplate.enabled }}
+{{- if and .Values.fluentbit.enabled .Values.fluentbit.outputs.es.enabled .Values.fluentbit.outputs.es.template.enabled }}
 {{- $envAll := . }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fluentbit-operator.name" . }}-es-template
+  name: {{ $.Release.Name }}-es-template
   namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "fluentbit-operator.name" . }}-operator
+    app: {{ template "fluentbit-operator.name" . }}
 {{ include "fluentbit-operator.labels" . | indent 4 }}
 spec:
   template:
     metadata:
-      name: {{ template "fluentbit-operator.name" . }}-es-template
+      name: {{ $.Release.Name }}-es-template
       labels:
-        app: {{ template "fluentbit-operator.name" . }}-operator
+        app: {{ template "fluentbit-operator.name" . }}
 {{ include "fluentbit-operator.labels" . | indent 8 }}
     spec:
 {{- if .Values.fluentbit.nodeSelector }}
@@ -31,40 +31,45 @@ spec:
         imagePullPolicy: "{{ .Values.image.elasticsearchTemplates.pullPolicy }}"
         env:
           - name: ES_URL
-            value: {{ .Values.fluentbit.esTemplate.url }}
+            value: https://{{.Values.fluentbit.outputs.es.host}}:{{.Values.fluentbit.outputs.es.port}}
           - name: ES_USER
-            value: {{ .Values.fluentbit.esTemplate.username }}
+            value: {{ .Values.fluentbit.outputs.es.username }}
           - name: ES_PW
-            value: {{ .Values.fluentbit.esTemplate.password }}
+            value: {{ .Values.fluentbit.outputs.es.password  }}
+          - name: ELASTIC_PW
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.fluentbit.outputs.es.elasticPasswordSecret  }}
+                key: elastic
         command:
         - /bin/sh
         - -c
         - /tmp/create_template.sh
         volumeMounts:
-        - name: {{ template "fluentbit-operator.name" . }}-cr-cm
+        - name: {{ $.Release.Name }}-cr-cm
           mountPath: /tmp/create_template.sh
           subPath: create_template.sh
           readOnly: true
-        {{ range .Values.fluentbit.esTemplate.templates }}
-        - name: {{ template "fluentbit-operator.name" $envAll }}-cr-cm
+        {{ range .Values.fluentbit.outputs.es.template.templates }}
+        - name: {{ $.Release.Name }}-cr-cm
           mountPath: /tmp/template-{{.name}}.json
           subPath: template-{{.name}}.json
           readOnly: true
         {{ end }}
-        {{ range .Values.fluentbit.esTemplate.ilms }}
-        - name: {{ template "fluentbit-operator.name" $envAll }}-cr-cm
+        {{ range .Values.fluentbit.outputs.es.template.ilms }}
+        - name: {{ $.Release.Name }}-cr-cm
           mountPath: /tmp/ilm-{{.name}}.json
           subPath: ilm-{{.name}}.json
           readOnly: true
         {{ end }}
         {{ range .Values.fluentbit.targetLogs }}
         {{if .index}}
-        - name: {{ template "fluentbit-operator.name" $envAll }}-cr-cm
+        - name: {{ $.Release.Name }}-cr-cm
           mountPath: /tmp/index-{{.index }}.json
           subPath: index-{{.index }}.json
           readOnly: true
           {{- range .multi_index}}
-        - name: {{ template "fluentbit-operator.name" $envAll }}-cr-cm
+        - name: {{ $.Release.Name }}-cr-cm
           mountPath: /tmp/index-{{.index }}.json
           subPath: index-{{.index }}.json
           readOnly: true
@@ -72,9 +77,9 @@ spec:
         {{ end }}
         {{ end }}
       volumes:
-      - name: {{ template "fluentbit-operator.name" . }}-cr-cm
+      - name: {{ $.Release.Name }}-cr-cm
         configMap:
-          name: {{ template "fluentbit-operator.name" . }}-cr-cm
+          name: {{ $.Release.Name }}-cr-cm
           defaultMode: 365
       restartPolicy: OnFailure
 {{- end }}

--- a/fluentbit-operator/templates/fluentbit/outputs.yaml
+++ b/fluentbit-operator/templates/fluentbit/outputs.yaml
@@ -5,12 +5,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fluentbit-operator.fullname" $envAll  }}-es-secret
+  name: {{ .Values.fluentbit.outputs.es.username }}-es-secret
   namespace: {{ $envAll.Release.Namespace }}
 type: Opaque
 data:
-  username: {{ .Values.fluentbit.outputs.es.username }}
-  password: {{ .Values.fluentbit.outputs.es.password }}
+  username: {{ .Values.fluentbit.outputs.es.username | b64enc }}
+  password: {{ .Values.fluentbit.outputs.es.password | b64enc }}
 {{- range $i, $input := $envAll.Values.fluentbit.targetLogs }}
 {{- if not $input.do_not_store_as_default}}
 ---

--- a/fluentbit-operator/values.yaml
+++ b/fluentbit-operator/values.yaml
@@ -31,7 +31,7 @@ image:
     pullPolicy: IfNotPresent
   hyperkube:
     repository: k8s.gcr.io/hyperkube
-    tag: v1.12.1
+    tag: v1.17.6
     pullPolicy: IfNotPresent
   fluentbit:
     repository: siim/fluent-bit-for-operator
@@ -187,7 +187,7 @@ fluentbit:
   #ORI    name: ""
     name: "fluentbit-operator"
 
-  daemomset:
+  daemonset:
     spec:
       ## Tolerations for use with node taints
       ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -337,16 +337,96 @@ fluentbit:
     type: etcd
     index: etcd
     parser: docker
-  # - name: journal
-  #   tag: journal.*
-  #   path: /var/log/journal
   outputs:
     es: 
       enabled: false
-      username: ZWxhc3RpYw==
-      password: dGFjb3dvcmQ=
+      createuser: false
+      username: fluentbit
+      password: password
+      elasticPasswordSecret: elasticsearch-es-elastic-user
       host: taco-elasticsearch-es-http.lma.svc.cluster.local
       port: 9200
+      template:
+        enabled: false
+        url: https://taco-elasticsearch-es-http.lma.svc.cluster.local:9200
+        ilms:
+        - name: hot-delete-14days
+          json:
+            policy:
+              phases:
+                hot:
+                  actions:
+                    rollover:
+                      max_size: 30gb
+                      max_age: 1d
+                      max_docs: 5000000000
+                    set_priority:
+                      priority: 100
+                delete:
+                  min_age: 14d
+                  actions:
+                    delete: {}
+        - name: hot-delete-7days
+          json:
+            policy:
+              phases:
+                hot:
+                  actions:
+                    rollover:
+                      max_size: 30gb
+                      max_age: 1d
+                      max_docs: 5000000000
+                    set_priority:
+                      priority: 100
+                delete:
+                  min_age: 7d
+                  actions:
+                    delete: {}
+        - name: hot-delete-3hour
+          json:
+            policy:
+              phases:
+                hot:
+                  actions:
+                    rollover:
+                      max_size: 30gb
+                      max_age: 1h
+                      max_docs: 5000000000
+                    set_priority:
+                      priority: 100
+                delete:
+                  min_age: 3h
+                  actions:
+                    delete: {}
+        templates:
+        - name: platform
+          json:
+            index_patterns: "platform*"
+            settings:
+              refresh_interval: 30s
+              number_of_shards: 3
+              number_of_replicas: 1
+              index.lifecycle.name: hot-delete-14days
+              index.lifecycle.rollover_alias: platform
+        - name: application
+          json:
+            index_patterns: "container*"
+            settings:
+              refresh_interval: 30s
+              number_of_shards: 3
+              number_of_replicas: 1
+              index.lifecycle.name: hot-delete-3hour
+              index.lifecycle.rollover_alias: container
+        - name: syslog
+          json:
+            index_patterns: "syslog*"
+            settings:
+              refresh_interval: 30s
+              number_of_shards: 2
+              number_of_replicas: 1
+              index.lifecycle.name: hot-delete-14days
+              index.lifecycle.rollover_alias: syslog
+
     kafka:
       enabled: false
       broker: my-kafka-0.my-kafka-headless.lma.svc.cluster.local:9092,
@@ -370,157 +450,6 @@ fluentbit:
       severity: critical
       regex: "update.?error"
 
-  esTemplate:
-    enabled: false
-    url: https://taco-elasticsearch-es-http.lma.svc.cluster.local:9200
-    username: elastic
-    password: tacoword
-    ilms:
-    - name: hot-delete-14days
-      json:
-        policy:
-          phases:
-            hot:
-              actions:
-                rollover:
-                  max_size: 30gb
-                  max_age: 1d
-                  max_docs: 5000000000
-                set_priority:
-                  priority: 100
-            delete:
-              min_age: 14d
-              actions:
-                delete: {}
-    - name: hot-delete-7days
-      json:
-        policy:
-          phases:
-            hot:
-              actions:
-                rollover:
-                  max_size: 30gb
-                  max_age: 1d
-                  max_docs: 5000000000
-                set_priority:
-                  priority: 100
-            delete:
-              min_age: 7d
-              actions:
-                delete: {}
-    - name: hot-delete-3hour
-      json:
-        policy:
-          phases:
-            hot:
-              actions:
-                rollover:
-                  max_size: 30gb
-                  max_age: 1h
-                  max_docs: 5000000000
-                set_priority:
-                  priority: 100
-            delete:
-              min_age: 3h
-              actions:
-                delete: {}
-    templates:
-    - name: platform
-      json:
-        index_patterns: "platform*"
-        settings:
-          refresh_interval: 30s
-          number_of_shards: 3
-          number_of_replicas: 1
-          index.lifecycle.name: hot-delete-14days
-          index.lifecycle.rollover_alias: platform
-        # mappings:
-        #   properties:
-        #     "@timestamp": 
-        #       type: date
-        #     cluster: 
-        #       type: text
-        #     kubernetes:
-        #       properties:
-        #         container_name:
-        #           type: keyword
-        #           index: true
-        #         container_name:
-        #           type: keyword
-        #           index: true
-        #         host: 
-        #           type: keyword
-        #           index: false
-        #         namespace:
-        #           type: keyword
-        #           index: false
-        #         pod_name:
-        #           type: keyword
-        #           index: true
-        #     log: 
-        #       type: text
-        #     status: 
-        #       type: long
-        #     time:
-        #       type: date
-    - name: application
-      json:
-        index_patterns: "container*"
-        settings:
-          refresh_interval: 30s
-          number_of_shards: 3
-          number_of_replicas: 1
-          index.lifecycle.name: hot-delete-3hour
-          index.lifecycle.rollover_alias: container
-        # mappings:
-        #   properties:
-        #     "@timestamp": 
-        #       type: date
-        #     cluster: 
-        #       type: text
-        #     kubernetes:
-        #       properties:
-        #         container_name:
-        #           type: keyword
-        #           index: true
-        #         container_name:
-        #           type: keyword
-        #           index: true
-        #         host: 
-        #           type: keyword
-        #           index: false
-        #         namespace:
-        #           type: keyword
-        #           index: false
-        #         pod_name:
-        #           type: keyword
-        #           index: true
-        #     log: 
-        #       type: text
-        #     status: 
-        #       type: long
-        #     time:
-        #       type: date
-    - name: syslog
-      json:
-        index_patterns: "syslog*"
-        settings:
-          refresh_interval: 30s
-          number_of_shards: 2
-          number_of_replicas: 1
-          index.lifecycle.name: hot-delete-14days
-          index.lifecycle.rollover_alias: syslog
-        # mappings:
-        #   properties:
-        #     "@timestamp": 
-        #       type: date
-        #     cluster: 
-        #       type: text
-        #     hostname: 
-        #       type: keyword
-        #       index: true
-        #     log: 
-        #       type: text
   # Define cluster name which is shown in collected logs
   clusterName: unknown
   exclude:


### PR DESCRIPTION
fluentbit 전용 계정 생성 및 사용하도록 수정

- fluentbit에서 사용할 전용 ES계정 생성
- fluentbit에서 이 계정을 연결하여 사용하도록 설정

리팩토링도 함께 들어감

- output의 es와 template을 분리하면서 애매했던 부분 수정
- 이름이 길게 그리고 모호하게 생성되던 부분을 정리

추후 고려할 만한 내용

- ES에서 RBAC 동작을 완전하게 만들 필요가 있음
- 필요한 role을 정의하여 그 범주에서만 사용자가 권한을 갖도록 연결
