### PR TITLE
kubernetes-event-exporter: use 'docker.io' explicitly for image repo

### DIFF
--- a/kubernetes-event-exporter/values.yaml
+++ b/kubernetes-event-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 nameOverride: event-exporter
 image:
-  repository: siim/kubernetes-event-exporter
+  repository: docker.io/siim/kubernetes-event-exporter
   tag: 0.1.0
   PullPolicy: IfNotPresent
 


### PR DESCRIPTION
tacoplay site-prepare 작업 시 외부 이미지 내역의 첫 번째 항목 (A/B/C 인 경우 A)을 저장소의 주소로 간주하고 내부 저장소로 치환하는 작업을 수행하게 됩니다. 따라서 'docker.io' 주소를 사용하지 않는 경우 오프라인 환경에서 오류가 발생하게 되어 해당 내용을 추가하였습니다.