### PR TITLE
bugfix: the fluentbit-operator chart supports kube-1.22

### DIFF
--- a/fluentbit-operator/Chart.yaml
+++ b/fluentbit-operator/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: fluentbit-operator
 sources:
 - https://github.com/intelliguy/fluentbit-operator
-version: 1.2.0
+version: 1.2.1

--- a/fluentbit-operator/crds/logging.kubesphere.io_parser.yaml
+++ b/fluentbit-operator/crds/logging.kubesphere.io_parser.yaml
@@ -1,0 +1,114 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: parsers.logging.kubesphere.io
+spec:
+  group: logging.kubesphere.io
+  names:
+    kind: Parser
+    listKind: ParserList
+    plural: parsers
+    singular: parser
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: Parser is the Schema for the parsers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ParserSpec defines the desired state of Parser
+            properties:
+              decoders:
+                description: 'Decoders are a built-in feature available through the
+                  Parsers file, each Parser definition can optionally set one or multiple
+                  decoders. There are two type of decoders type: Decode_Field and
+                  Decode_Field_As.'
+                items:
+                  properties:
+                    decodeField:
+                      description: If the content can be decoded in a structured message,
+                        append that structure message (keys and values) to the original
+                        log message.
+                      type: string
+                    decodeFieldAs:
+                      description: Any content decoded (unstructured or structured)
+                        will be replaced in the same key/value, no extra keys are
+                        added.
+                      type: string
+                  type: object
+                type: array
+              json:
+                description: JSON defines json parser configuration.
+                properties:
+                  timeFormat:
+                    description: Time_Format, eg. %Y-%m-%dT%H:%M:%S %z
+                    type: string
+                  timeKeep:
+                    description: Time_Keep
+                    type: boolean
+                  timeKey:
+                    description: Time_Key
+                    type: string
+                type: object
+              logfmt:
+                description: Logfmt defines logfmt parser configuration.
+                type: object
+              ltsv:
+                description: LTSV defines ltsv parser configuration.
+                properties:
+                  timeFormat:
+                    description: Time_Format, eg. %Y-%m-%dT%H:%M:%S %z
+                    type: string
+                  timeKeep:
+                    description: Time_Keep
+                    type: boolean
+                  timeKey:
+                    description: Time_Key
+                    type: string
+                  types:
+                    type: string
+                type: object
+              regex:
+                description: Regex defines regex parser configuration.
+                properties:
+                  regex:
+                    type: string
+                  timeFormat:
+                    description: Time_Format, eg. %Y-%m-%dT%H:%M:%S %z
+                    type: string
+                  timeKeep:
+                    description: Time_Keep
+                    type: boolean
+                  timeKey:
+                    description: Time_Key
+                    type: string
+                  types:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
kubesphere의 operator가 fluent에 공식으로 들어가면서 crd, api등이 많이 바뀌었네요.
해당 내용을 반영하여 추가함

테스트는 아직 못해봐서 b환경에 테스트 하면서 같이 보고 merge할께요

version 1.2.1은 수동으로 helm-repo에 올림

17:30 추가
해당 repo가 계속 변경되면서 혼돈이 있네요. 지금 우리가 올린 버전은 아래와 같습니다.
- https://github.com/fluent/fluentbit-operator/tree/25bc31cd4333f7f77435561ec70bc68e0c73a194 
release 브랜치를 사용하지 않은 이유는 몇몇 사용해야 하는 기능이 포함된 릴리즈가 그때 그리고 현재로 존재하지 않기 때문이고
이에따라 앞에서 보았던 api버전을 찾는 이슈가 발생했습니다. 결론은 기존에 parser만 추가하면 되는 문제로 보여짐