### PR TITLE
add keycloak-operator chart

### DIFF
--- a/keycloak-operator/.helmignore
+++ b/keycloak-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/keycloak-operator/Chart.yaml
+++ b/keycloak-operator/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: keycloak-operator
+description: A Helm chart for keycloak-operator (https://github.com/keycloak/keycloak-operator)
+
+type: application
+
+version: 0.1.0
+
+appVersion: "17.0.0"

--- a/keycloak-operator/crds/keycloak.org_keycloakbackups_crd.yaml
+++ b/keycloak-operator/crds/keycloak.org_keycloakbackups_crd.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created
+                  on AWS S3 instead of a local Persistent Volume. If this property
+                  is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS
+                      S3 Service. The secret needs to be in the following form: \n
+                      \    apiVersion: v1     kind: Secret     metadata:       name:
+                      <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME:
+                      <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>
+                      \      AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information,
+                      please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted.
+                      Provides a secret name used for encrypting database data. The
+                      secret needs to be in the following form: \n     apiVersion:
+                      v1     kind: Secret     metadata:       name: <Secret name>
+                      \    type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG
+                      Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT:
+                      <GPG Recipient> \n For more information, please refer to the
+                      Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating
+                      a CronJob.
+                    type: string
+                type: object
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented.
+                  \n In the future this will be used to trigger automatic restore
+                  for a given KeycloakBackup. Each backup will correspond to a single
+                  snapshot of the database (stored either in a Persistent Volume or
+                  AWS). If a user wants to restore it, all he/she needs to do is to
+                  change this flag to true. Potentially, it will be possible to restore
+                  a single backup multiple times."
+                type: boolean
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Backup Persistent
+                  Volume Claim
+                type: string
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+            properties:
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/keycloak-operator/crds/keycloak.org_keycloakclients_crd.yaml
+++ b/keycloak-operator/crds/keycloak.org_keycloakclients_crd.yaml
@@ -1,0 +1,848 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
+                  authorizationServicesEnabled:
+                    description: True if fine-grained authorization support is enabled
+                      for this client.
+                    type: boolean
+                  authorizationSettings:
+                    description: Authorization settings for this resource server.
+                    properties:
+                      allowRemoteResourceManagement:
+                        description: True if resources should be managed remotely
+                          by the resource server.
+                        type: boolean
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      decisionStrategy:
+                        description: The decision strategy dictates how permissions
+                          are evaluated and how a final decision is obtained. 'Affirmative'
+                          means that at least one permission must evaluate to a positive
+                          decision in order to grant access to a resource and its
+                          scopes. 'Unanimous' means that all permissions must evaluate
+                          to a positive decision in order for the final decision to
+                          be also positive.
+                        type: string
+                      id:
+                        description: ID.
+                        type: string
+                      name:
+                        description: Name.
+                        type: string
+                      policies:
+                        description: Policies.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config.
+                              type: object
+                            decisionStrategy:
+                              description: The decision strategy dictates how the
+                                policies associated with a given permission are evaluated
+                                and how a final decision is obtained. 'Affirmative'
+                                means that at least one policy must evaluate to a
+                                positive decision in order for the final decision
+                                to be also positive. 'Unanimous' means that all policies
+                                must evaluate to a positive decision in order for
+                                the final decision to be also positive. 'Consensus'
+                                means that the number of positive decisions must be
+                                greater than the number of negative decisions. If
+                                the number of positive and negative is the same, the
+                                final decision will be negative.
+                              type: string
+                            description:
+                              description: A description for this policy.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            logic:
+                              description: The logic dictates how the policy decision
+                                should be made. If 'Positive', the resulting effect
+                                (permit or deny) obtained during the evaluation of
+                                this policy will be used to perform a decision. If
+                                'Negative', the resulting effect will be negated,
+                                in other words, a permit becomes a deny and vice-versa.
+                              type: string
+                            name:
+                              description: The name of this policy.
+                              type: string
+                            owner:
+                              description: Owner.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                type: string
+                              type: array
+                            resourcesData:
+                              description: Resources Data.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the
+                                      resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource.
+                                      The name can be used to uniquely identify a
+                                      resource, useful when querying for a specific
+                                      resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource.
+                                      The name can be used to uniquely identify a
+                                      resource, useful when querying for a specific
+                                      resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource
+                                      can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can
+                                      be used to group different resource instances
+                                      with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by
+                                      resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Scopes.
+                              items:
+                                type: string
+                              type: array
+                            scopesData:
+                              description: Scopes Data.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: Type.
+                              type: string
+                          type: object
+                        type: array
+                      policyEnforcementMode:
+                        description: The policy enforcement mode dictates how policies
+                          are enforced when evaluating authorization requests. 'Enforcing'
+                          means requests are denied by default even when there is
+                          no policy associated with a given resource. 'Permissive'
+                          means requests are allowed even when there is no policy
+                          associated with a given resource. 'Disabled' completely
+                          disables the evaluation of policies and allows access to
+                          any resource.
+                        type: string
+                      resources:
+                        description: Resources.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                          properties:
+                            _id:
+                              description: ID.
+                              type: string
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: The attributes associated with the resource.
+                              type: object
+                            displayName:
+                              description: A unique name for this resource. The name
+                                can be used to uniquely identify a resource, useful
+                                when querying for a specific resource.
+                              type: string
+                            icon_uri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            name:
+                              description: A unique name for this resource. The name
+                                can be used to uniquely identify a resource, useful
+                                when querying for a specific resource.
+                              type: string
+                            ownerManagedAccess:
+                              description: True if the access to this resource can
+                                be managed by the resource owner.
+                              type: boolean
+                            scopes:
+                              description: The scopes associated with this resource.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: The type of this resource. It can be used
+                                to group different resource instances with the same
+                                type.
+                              type: string
+                            uris:
+                              description: Set of URIs which are protected by resource.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      scopes:
+                        description: Authorization Scopes.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                          properties:
+                            displayName:
+                              description: A unique name for this scope. The name
+                                can be used to uniquely identify a scope, useful when
+                                querying for a specific scope.
+                              type: string
+                            iconUri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: A unique name for this scope. The name
+                                can be used to uniquely identify a scope, useful when
+                                querying for a specific scope.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how
+                                      the policies associated with a given permission
+                                      are evaluated and how a final decision is obtained.
+                                      'Affirmative' means that at least one policy
+                                      must evaluate to a positive decision in order
+                                      for the final decision to be also positive.
+                                      'Unanimous' means that all policies must evaluate
+                                      to a positive decision in order for the final
+                                      decision to be also positive. 'Consensus' means
+                                      that the number of positive decisions must be
+                                      greater than the number of negative decisions.
+                                      If the number of positive and negative is the
+                                      same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy
+                                      decision should be made. If 'Positive', the
+                                      resulting effect (permit or deny) obtained during
+                                      the evaluation of this policy will be used to
+                                      perform a decision. If 'Negative', the resulting
+                                      effect will be negated, in other words, a permit
+                                      becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with
+                                            the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource.
+                                            The name can be used to uniquely identify
+                                            a resource, useful when querying for a
+                                            specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource.
+                                            The name can be used to uniquely identify
+                                            a resource, useful when querying for a
+                                            specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this
+                                            resource can be managed by the resource
+                                            owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with
+                                            this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource.
+                                            It can be used to group different resource
+                                            instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected
+                                            by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the
+                                      resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource.
+                                      The name can be used to uniquely identify a
+                                      resource, useful when querying for a specific
+                                      resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource.
+                                      The name can be used to uniquely identify a
+                                      resource, useful when querying for a specific
+                                      resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource
+                                      can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can
+                                      be used to group different resource instances
+                                      with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by
+                                      resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultClientScopes:
+                    description: A list of default client scopes. Default client scopes
+                      are always applied when issuing OpenID Connect tokens or SAML
+                      assertions for this client.
+                    items:
+                      type: string
+                    type: array
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  optionalClientScopes:
+                    description: A list of optional client scopes. Optional client
+                      scopes are applied when issuing tokens for this client, but
+                      only when they are requested by the scope parameter in the OpenID
+                      Connect authorization request.
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create
+                      a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              roles:
+                description: Client Roles
+                items:
+                  description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Role Attributes
+                      type: object
+                    clientRole:
+                      description: Client Role
+                      type: boolean
+                    composite:
+                      description: Composite
+                      type: boolean
+                    composites:
+                      description: Composites
+                      properties:
+                        client:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Map client => []role
+                          type: object
+                        realm:
+                          description: Realm roles
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    containerId:
+                      description: Container Id
+                      type: string
+                    description:
+                      description: Description
+                      type: string
+                    id:
+                      description: Id
+                      type: string
+                    name:
+                      description: Name
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              scopeMappings:
+                description: Scope Mappings
+                properties:
+                  clientMappings:
+                    additionalProperties:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        mappings:
+                          description: Mappings
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    description: Client Mappings
+                    type: object
+                  realmMappings:
+                    description: Realm Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Role Attributes
+                          type: object
+                        clientRole:
+                          description: Client Role
+                          type: boolean
+                        composite:
+                          description: Composite
+                          type: boolean
+                        composites:
+                          description: Composites
+                          properties:
+                            client:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Map client => []role
+                              type: object
+                            realm:
+                              description: Realm roles
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        containerId:
+                          description: Container Id
+                          type: string
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: Id
+                          type: string
+                        name:
+                          description: Name
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/keycloak-operator/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/keycloak-operator/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -1,0 +1,1366 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  accessTokenLifespan:
+                    description: Access Token Lifespan
+                    format: int32
+                    type: integer
+                  accessTokenLifespanForImplicitFlow:
+                    description: Access Token Lifespan For Implicit Flow
+                    format: int32
+                    type: integer
+                  accountTheme:
+                    description: Account Theme
+                    type: string
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values
+                      and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and
+                      use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminTheme:
+                    description: Admin Console Theme
+                    type: string
+                  authenticationFlows:
+                    description: Authentication flows
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        authenticationExecutions:
+                          description: Authentication executions
+                          items:
+                            properties:
+                              authenticator:
+                                description: Authenticator
+                                type: string
+                              authenticatorConfig:
+                                description: Authenticator Config
+                                type: string
+                              authenticatorFlow:
+                                description: Authenticator flow
+                                type: boolean
+                              flowAlias:
+                                description: Flow Alias
+                                type: string
+                              priority:
+                                description: Priority
+                                format: int32
+                                type: integer
+                              requirement:
+                                description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE,
+                                  DISABLED]
+                                type: string
+                              userSetupAllowed:
+                                description: User setup allowed
+                                type: boolean
+                            type: object
+                          type: array
+                        builtIn:
+                          description: Built in
+                          type: boolean
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        providerId:
+                          description: Provider ID
+                          type: string
+                        topLevel:
+                          description: Top level
+                          type: boolean
+                      required:
+                      - alias
+                      - authenticationExecutions
+                      type: object
+                    type: array
+                  authenticatorConfig:
+                    description: Authenticator config
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config
+                          type: object
+                        id:
+                          description: ID
+                          type: string
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  bruteForceProtected:
+                    description: Brute Force Detection
+                    type: boolean
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                        properties:
+                          client:
+                            description: Client
+                            type: string
+                          clientScope:
+                            description: Client Scope
+                            type: string
+                          roles:
+                            description: Roles
+                            items:
+                              type: string
+                            type: array
+                          self:
+                            description: Self
+                            type: string
+                        type: object
+                      type: array
+                    description: Client Scope Mappings
+                    type: object
+                  clientScopes:
+                    description: Client scopes
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        protocol:
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
+                        authorizationServicesEnabled:
+                          description: True if fine-grained authorization support
+                            is enabled for this client.
+                          type: boolean
+                        authorizationSettings:
+                          description: Authorization settings for this resource server.
+                          properties:
+                            allowRemoteResourceManagement:
+                              description: True if resources should be managed remotely
+                                by the resource server.
+                              type: boolean
+                            clientId:
+                              description: Client ID.
+                              type: string
+                            decisionStrategy:
+                              description: The decision strategy dictates how permissions
+                                are evaluated and how a final decision is obtained.
+                                'Affirmative' means that at least one permission must
+                                evaluate to a positive decision in order to grant
+                                access to a resource and its scopes. 'Unanimous' means
+                                that all permissions must evaluate to a positive decision
+                                in order for the final decision to be also positive.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: Name.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how
+                                      the policies associated with a given permission
+                                      are evaluated and how a final decision is obtained.
+                                      'Affirmative' means that at least one policy
+                                      must evaluate to a positive decision in order
+                                      for the final decision to be also positive.
+                                      'Unanimous' means that all policies must evaluate
+                                      to a positive decision in order for the final
+                                      decision to be also positive. 'Consensus' means
+                                      that the number of positive decisions must be
+                                      greater than the number of negative decisions.
+                                      If the number of positive and negative is the
+                                      same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy
+                                      decision should be made. If 'Positive', the
+                                      resulting effect (permit or deny) obtained during
+                                      the evaluation of this policy will be used to
+                                      perform a decision. If 'Negative', the resulting
+                                      effect will be negated, in other words, a permit
+                                      becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with
+                                            the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource.
+                                            The name can be used to uniquely identify
+                                            a resource, useful when querying for a
+                                            specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource.
+                                            The name can be used to uniquely identify
+                                            a resource, useful when querying for a
+                                            specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this
+                                            resource can be managed by the resource
+                                            owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with
+                                            this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource.
+                                            It can be used to group different resource
+                                            instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected
+                                            by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            policyEnforcementMode:
+                              description: The policy enforcement mode dictates how
+                                policies are enforced when evaluating authorization
+                                requests. 'Enforcing' means requests are denied by
+                                default even when there is no policy associated with
+                                a given resource. 'Permissive' means requests are
+                                allowed even when there is no policy associated with
+                                a given resource. 'Disabled' completely disables the
+                                evaluation of policies and allows access to any resource.
+                              type: string
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the
+                                      resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource.
+                                      The name can be used to uniquely identify a
+                                      resource, useful when querying for a specific
+                                      resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource.
+                                      The name can be used to uniquely identify a
+                                      resource, useful when querying for a specific
+                                      resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource
+                                      can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can
+                                      be used to group different resource instances
+                                      with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by
+                                      resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Authorization Scopes.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                                properties:
+                                  displayName:
+                                    description: A unique name for this scope. The
+                                      name can be used to uniquely identify a scope,
+                                      useful when querying for a specific scope.
+                                    type: string
+                                  iconUri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  name:
+                                    description: A unique name for this scope. The
+                                      name can be used to uniquely identify a scope,
+                                      useful when querying for a specific scope.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                      properties:
+                                        config:
+                                          additionalProperties:
+                                            type: string
+                                          description: Config.
+                                          type: object
+                                        decisionStrategy:
+                                          description: The decision strategy dictates
+                                            how the policies associated with a given
+                                            permission are evaluated and how a final
+                                            decision is obtained. 'Affirmative' means
+                                            that at least one policy must evaluate
+                                            to a positive decision in order for the
+                                            final decision to be also positive. 'Unanimous'
+                                            means that all policies must evaluate
+                                            to a positive decision in order for the
+                                            final decision to be also positive. 'Consensus'
+                                            means that the number of positive decisions
+                                            must be greater than the number of negative
+                                            decisions. If the number of positive and
+                                            negative is the same, the final decision
+                                            will be negative.
+                                          type: string
+                                        description:
+                                          description: A description for this policy.
+                                          type: string
+                                        id:
+                                          description: ID.
+                                          type: string
+                                        logic:
+                                          description: The logic dictates how the
+                                            policy decision should be made. If 'Positive',
+                                            the resulting effect (permit or deny)
+                                            obtained during the evaluation of this
+                                            policy will be used to perform a decision.
+                                            If 'Negative', the resulting effect will
+                                            be negated, in other words, a permit becomes
+                                            a deny and vice-versa.
+                                          type: string
+                                        name:
+                                          description: The name of this policy.
+                                          type: string
+                                        owner:
+                                          description: Owner.
+                                          type: string
+                                        policies:
+                                          description: Policies.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resources:
+                                          description: Resources.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resourcesData:
+                                          description: Resources Data.
+                                          items:
+                                            description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                            properties:
+                                              _id:
+                                                description: ID.
+                                                type: string
+                                              attributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: The attributes associated
+                                                  with the resource.
+                                                type: object
+                                              displayName:
+                                                description: A unique name for this
+                                                  resource. The name can be used to
+                                                  uniquely identify a resource, useful
+                                                  when querying for a specific resource.
+                                                type: string
+                                              icon_uri:
+                                                description: An URI pointing to an
+                                                  icon.
+                                                type: string
+                                              name:
+                                                description: A unique name for this
+                                                  resource. The name can be used to
+                                                  uniquely identify a resource, useful
+                                                  when querying for a specific resource.
+                                                type: string
+                                              ownerManagedAccess:
+                                                description: True if the access to
+                                                  this resource can be managed by
+                                                  the resource owner.
+                                                type: boolean
+                                              scopes:
+                                                description: The scopes associated
+                                                  with this resource.
+                                                items:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                type: array
+                                              type:
+                                                description: The type of this resource.
+                                                  It can be used to group different
+                                                  resource instances with the same
+                                                  type.
+                                                type: string
+                                              uris:
+                                                description: Set of URIs which are
+                                                  protected by resource.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          description: Scopes.
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopesData:
+                                          description: Scopes Data.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: Type.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with
+                                            the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource.
+                                            The name can be used to uniquely identify
+                                            a resource, useful when querying for a
+                                            specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource.
+                                            The name can be used to uniquely identify
+                                            a resource, useful when querying for a
+                                            specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this
+                                            resource can be managed by the resource
+                                            owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with
+                                            this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource.
+                                            It can be used to group different resource
+                                            instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected
+                                            by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultClientScopes:
+                          description: A list of default client scopes. Default client
+                            scopes are always applied when issuing OpenID Connect
+                            tokens or SAML assertions for this client.
+                          items:
+                            type: string
+                          type: array
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel
+                            logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically
+                            generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        optionalClientScopes:
+                          description: A list of optional client scopes. Optional
+                            client scopes are applied when issuing tokens for this
+                            client, but only when they are requested by the scope
+                            parameter in the OpenID Connect authorization request.
+                          items:
+                            type: string
+                          type: array
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically
+                            create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  defaultLocale:
+                    description: Default Locale
+                    type: string
+                  defaultRole:
+                    description: Default role
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  displayNameHtml:
+                    description: Realm HTML display name.
+                    type: string
+                  duplicateEmailsAllowed:
+                    description: Duplicate emails
+                    type: boolean
+                  editUsernameAllowed:
+                    description: Edit username
+                    type: boolean
+                  emailTheme:
+                    description: Email Theme
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  enabledEventTypes:
+                    description: Enabled event types
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and
+                      use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  failureFactor:
+                    description: Max Login Failures
+                    format: int32
+                    type: integer
+                  id:
+                    type: string
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity
+                            Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  internationalizationEnabled:
+                    description: Internationalization Enabled
+                    type: boolean
+                  loginTheme:
+                    description: Login Theme
+                    type: string
+                  loginWithEmailAllowed:
+                    description: Login with email
+                    type: boolean
+                  maxDeltaTimeSeconds:
+                    description: Failure Reset Time
+                    format: int32
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: Max Wait
+                    format: int32
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: Minimum Quick Login Wait
+                    format: int32
+                    type: integer
+                  passwordPolicy:
+                    description: Realm Password Policy
+                    type: string
+                  permanentLockout:
+                    description: Permanent Lockout
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: Quick Login Check Milli Seconds
+                    format: int64
+                    type: integer
+                  realm:
+                    description: Realm name.
+                    type: string
+                  registrationAllowed:
+                    description: User registration
+                    type: boolean
+                  registrationEmailAsUsername:
+                    description: Email as username
+                    type: boolean
+                  rememberMe:
+                    description: Remember me
+                    type: boolean
+                  resetPasswordAllowed:
+                    description: Forgot password
+                    type: boolean
+                  roles:
+                    description: Roles
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        description: Client Roles
+                        type: object
+                      realm:
+                        description: Realm Roles
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  scopeMappings:
+                    description: Scope Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  smtpServer:
+                    additionalProperties:
+                      type: string
+                    description: Email
+                    type: object
+                  sslRequired:
+                    description: Require SSL
+                    type: string
+                  supportedLocales:
+                    description: Supported Locales
+                    items:
+                      type: string
+                    type: array
+                  userFederationMappers:
+                    description: User federation mappers are extension points triggered
+                      by the user federation at various points.
+                    items:
+                      description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers
+                        https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation mapper config.
+                          type: object
+                        federationMapperType:
+                          type: string
+                        federationProviderDisplayName:
+                          description: The displayName for the user federation provider
+                            this mapper applies to.
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  userFederationProviders:
+                    description: Point keycloak to an external user provider to validate
+                      credentials or pull in identity information.
+                    items:
+                      description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation provider config.
+                          type: object
+                        displayName:
+                          description: The display name of this provider instance.
+                          type: string
+                        fullSyncPeriod:
+                          format: int32
+                          type: integer
+                        id:
+                          description: The ID of this provider
+                          type: string
+                        priority:
+                          description: The priority of this provider when looking
+                            up users or adding a user.
+                          format: int32
+                          type: integer
+                        providerName:
+                          description: The name of the user provider, such as "ldap",
+                            "kerberos" or a custom SPI.
+                          type: string
+                      type: object
+                    type: array
+                  userManagedAccessAllowed:
+                    description: User Managed Access Allowed
+                    type: boolean
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Attributes.
+                          type: object
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                  verifyEmail:
+                    description: Verify email
+                    type: boolean
+                  waitIncrementSeconds:
+                    description: Wait Increment
+                    format: int32
+                    type: integer
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  required:
+                  - identityProvider
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              unmanaged:
+                description: When set to true, this KeycloakRealm will be marked as
+                  unmanaged and not be managed by this operator. It can then be used
+                  for targeting purposes.
+                type: boolean
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/keycloak-operator/crds/keycloak.org_keycloaks_crd.yaml
+++ b/keycloak-operator/crds/keycloak.org_keycloaks_crd.yaml
@@ -1,0 +1,1108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR
+                  files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              external:
+                description: Contains configuration for external Keycloak instances.
+                  Unmanaged needs to be set to true to use this.
+                properties:
+                  enabled:
+                    description: If set to true, this Keycloak will be treated as
+                      an external instance. The unmanaged field also needs to be set
+                      to true if this field is true.
+                    type: boolean
+                  url:
+                    description: The URL to use for the keycloak admin API. Needs
+                      to be set if external is true.
+                    type: string
+                type: object
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress
+                      or a Route pointing to Keycloak.
+                    type: boolean
+                  host:
+                    description: If set, the Operator will use value of host for Ingress
+                      host instead of default value keycloak.local. Using this setting
+                      in OpenShift environment will result an error. Only users with
+                      special permissions are allowed to modify the hostname.
+                    type: string
+                  tlsTermination:
+                    description: TLS Termination type for the external access. Setting
+                      this field to "reencrypt" will terminate TLS on the Ingress/Route
+                      level. Setting this field to "passthrough" will send encrypted
+                      traffic to the Pod. If unspecified, defaults to "reencrypt".
+                      Note, that this setting has no effect on Ingress as Ingress
+                      TLS settings are not reconciled by this operator. In other words,
+                      Ingress TLS configuration is the same in both cases and it is
+                      up to the user to configure TLS section of the Ingress.
+                    type: string
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external
+                  database requires providing a secret containing credentials as well
+                  as connection details. Here's an example of such secret: \n     apiVersion:
+                  v1     kind: Secret     metadata:         name: keycloak-db-secret
+                  \        namespace: keycloak     stringData:         POSTGRES_DATABASE:
+                  <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database
+                  IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External
+                  Database Port>         # Strongly recommended to use <'Keycloak
+                  CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>
+                  \        POSTGRES_PASSWORD: <Database Password>         # Required
+                  for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME:
+                  <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS
+                  and POSTGRES_EXTERNAL_PORT are specifically required for creating
+                  connection to the external database. The secret name is created
+                  using the following convention:       <Custom Resource Name>-db-secret
+                  \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external
+                      database pointing to Keycloak. The embedded database (externalDatabase.enabled
+                      = false) is deprecated.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              keycloakDeploymentSpec:
+                description: Resources (Requests and Limits) for KeycloakDeployment.
+                properties:
+                  experimental:
+                    description: 'Experimental section NOTE: This section might change
+                      or get removed without any notice. It may also cause the deployment
+                      to behave in an unpredictable fashion. Please use with care.'
+                    properties:
+                      affinity:
+                        description: Affinity settings
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      args:
+                        description: Arguments to the entrypoint. Translates into
+                          Container CMD.
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Container command. Translates into Container
+                          ENTRYPOINT.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
+                      volumes:
+                        description: Additional volume mounts
+                        properties:
+                          defaultMode:
+                            description: Permissions mode.
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                configMaps:
+                                  description: Allow multiple configmaps to mount
+                                    to the same directory
+                                  items:
+                                    type: string
+                                  type: array
+                                items:
+                                  description: Mount details
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file. Must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                mountPath:
+                                  description: An absolute path where to mount it
+                                  type: string
+                                name:
+                                  description: Volume name
+                                  type: string
+                                secrets:
+                                  description: Secret mount
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - mountPath
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  podlabels:
+                    additionalProperties:
+                      type: string
+                    description: List of labels to set in the keycloak pods
+                    type: object
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              migration:
+                description: Specify Migration configuration
+                properties:
+                  backups:
+                    description: Set it to config backup policy for migration
+                    properties:
+                      enabled:
+                        description: If set to true, the operator will do database
+                          backup before doing migration
+                        type: boolean
+                    type: object
+                  strategy:
+                    description: Specify migration strategy
+                    type: string
+                type: object
+              multiAvailablityZones:
+                description: Specify PodAntiAffinity settings for Keycloak deployment
+                  in Multi AZ
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a podAntiAffinity
+                      settings for the Keycloak deployment.
+                    type: boolean
+                type: object
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration.
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget
+                      for the Keycloak deployment and set its `maxUnavailable` value
+                      to 1.
+                    type: boolean
+                type: object
+              postgresDeploymentSpec:
+                description: Resources (Requests and Limits) for PostgresDeployment.
+                properties:
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default
+                  is empty.
+                type: string
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Persistent Volume
+                  Claim
+                type: string
+              unmanaged:
+                description: When set to true, this Keycloak will be marked as unmanaged
+                  and will not be managed by this operator. It can then be used for
+                  targeting purposes.
+                type: boolean
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found.
+                type: string
+              externalURL:
+                description: External URL for accessing Keycloak instance from outside
+                  the cluster. Is identical to external.URL if it's specified, otherwise
+                  is computed (e.g. from Ingress).
+                type: string
+              internalURL:
+                description: An internal URL (service name) to be used by the admin
+                  client.
+                type: string
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ].'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster.
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/keycloak-operator/crds/keycloak.org_keycloakusers_crd.yaml
+++ b/keycloak-operator/crds/keycloak.org_keycloakusers_crd.yaml
@@ -1,0 +1,183 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser.
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Attributes.
+                    type: object
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser.
+            properties:
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/keycloak-operator/templates/_helpers.tpl
+++ b/keycloak-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak-operator.labels" -}}
+helm.sh/chart: {{ include "keycloak-operator.chart" . }}
+{{ include "keycloak-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keycloak-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keycloak-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/keycloak-operator/templates/deploy-keycloak-operator.yaml
+++ b/keycloak-operator/templates/deploy-keycloak-operator.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-operator
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: keycloak-operator
+  template:
+    metadata:
+      labels:
+        name: keycloak-operator
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: keycloak-operator
+      containers:
+        - name: keycloak-operator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - keycloak-operator
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "keycloak-operator"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/keycloak-operator/templates/role.yaml
+++ b/keycloak-operator/templates/role.yaml
@@ -1,0 +1,136 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - list
+  - get
+  - create
+  - patch
+  - update
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - create
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+    - cronjobs
+    - jobs
+  verbs:
+    - list
+    - get
+    - create
+    - update
+    - watch
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes/custom-host
+  verbs:
+    - create
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - list
+  - get
+  - create
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - get
+  - create
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - list
+  - get
+  - create
+  - update
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanadashboards
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resourceNames:
+  - keycloak-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+- apiGroups:
+  - keycloak.org
+  resources:
+  - keycloaks
+  - keycloaks/status
+  - keycloaks/finalizers
+  - keycloakrealms
+  - keycloakrealms/status
+  - keycloakrealms/finalizers
+  - keycloakclients
+  - keycloakclients/status
+  - keycloakclients/finalizers
+  - keycloakbackups
+  - keycloakbackups/status
+  - keycloakbackups/finalizers
+  - keycloakusers
+  - keycloakusers/status
+  - keycloakusers/finalizers
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/keycloak-operator/templates/role_binding.yaml
+++ b/keycloak-operator/templates/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: keycloak-operator
+subjects:
+- kind: ServiceAccount
+  name: keycloak-operator
+roleRef:
+  kind: Role
+  name: keycloak-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/keycloak-operator/templates/service_account.yaml
+++ b/keycloak-operator/templates/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-operator

--- a/keycloak-operator/values.yaml
+++ b/keycloak-operator/values.yaml
@@ -1,0 +1,29 @@
+# Default values for keycloak-operator.
+
+replicaCount: 1
+
+image:
+  repository: quay.io/keycloak/keycloak-operator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
keycloak-operator (https://github.com/keycloak/keycloak-operator) 배포를 위한 차트를 추가합니다. keycloak 인스턴스 및 자원 (realm, user, client 등) 생성을 위한 차트는 keycloak-resources (가칭) 으로 분리해서 작업하겠습니다.