### PR TITLE
add keycloak-resources for keycloak-operator

### DIFF
--- a/keycloak-resources/Chart.yaml
+++ b/keycloak-resources/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: keycloak-resources deployment for keycloak-operator
+description: A Helm chart for keycloak-operator CRs deployment
+
+type: application
+
+version: 0.1.0
+
+appVersion: "17.0.0"

--- a/keycloak-resources/templates/_helpers.tpl
+++ b/keycloak-resources/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak-resources.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak-resources.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak-resources.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak-resources.labels" -}}
+helm.sh/chart: {{ include "keycloak-resources.chart" . }}
+{{ include "keycloak-resources.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak-resources.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak-resources.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keycloak-resources.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keycloak-resources.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/keycloak-resources/templates/keycloak-client.yaml
+++ b/keycloak-resources/templates/keycloak-client.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.keycloakClient }}
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: {{ .name }}
+  labels:
+    client: {{ .name }}
+spec:
+  realmSelector:
+    matchLabels:
+      realm: {{ .realm }}
+  client:
+    clientId: {{ .name }}
+    protocol: {{ .protocol }}
+    rootUrl: {{ .rootUrl }}
+{{- end }}

--- a/keycloak-resources/templates/keycloak-realm.yaml
+++ b/keycloak-resources/templates/keycloak-realm.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.keycloakRealm }}
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  name: {{ .name }}
+  labels:
+    realm: {{ .name }}
+spec:
+  realm:
+    realm: "{{ .name }}"
+    enabled: True
+    displayName: "{{ .displayName }}"
+  instanceSelector:
+    matchLabels:
+      app: "{{ .name }}"
+{{- end }}

--- a/keycloak-resources/templates/keycloak-user.yaml
+++ b/keycloak-resources/templates/keycloak-user.yaml
@@ -1,0 +1,21 @@
+{{- range .Values.keycloakUser }}
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakUser
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ .name }}
+spec:
+  user:
+    username: "{{ .name }}"
+    firstName: "{{ .firstName }}"
+    lastName: "{{ .lastName }}"
+    email: "{{ .email }}"
+    enabled: True
+    credentials:
+      - type: "password"
+        value: "{{ .password }}"
+  realmSelector:
+    matchLabels:
+      realm: {{ .realm }}
+{{- end }}

--- a/keycloak-resources/templates/keycloak.yaml
+++ b/keycloak-resources/templates/keycloak.yaml
@@ -1,0 +1,16 @@
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: {{ .Values.keycloak.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.keycloak.name }}
+spec:
+  instances: {{ .Values.keycloak.replicas }}
+  externalDatabase:
+    enabled: {{ .Values.keycloak.externalDatabase.enabled }}
+  {{- if not .Values.keycloak.externalDatabase.enabled }}
+  storageClassName: {{ .Values.keycloak.storageClassName }}
+  {{- end }}
+  externalAccess:
+    enabled: {{ .Values.keycloak.externalAccessEnabled }}

--- a/keycloak-resources/templates/secret-database.yaml
+++ b/keycloak-resources/templates/secret-database.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: keycloak-db-secret
+    namespace: keycloak
+stringData:
+    POSTGRES_DATABASE: "{{ .Values.keycloak.externalDatabase.databaseName }}"
+    # MUST BE FQDN FOR ADDRESS
+    POSTGRES_EXTERNAL_ADDRESS: "{{ .Values.keycloak.externalDatabase.address }}"
+    POSTGRES_EXTERNAL_PORT: "{{ .Values.keycloak.externalDatabase.port }}"
+    POSTGRES_PASSWORD: "{{ .Values.keycloak.externalDatabase.password }}"
+    # Required for AWS Backup functionality
+    POSTGRES_SUPERUSER: "{{ .Values.keycloak.externalDatabase.superuserEnabled }}"
+    POSTGRES_USERNAME: "{{ .Values.keycloak.externalDatabase.username }}"
+type: Opaque

--- a/keycloak-resources/values.yaml
+++ b/keycloak-resources/values.yaml
@@ -1,0 +1,33 @@
+# Default values for keycloak-resources.
+
+keycloak:
+  name: mykeycloak
+  replicas: 1
+  externalDatabase:
+    enabled: true
+    address: postgresql.decapod-db.svc.cluster.local # Shoud be FQDN
+    port: 5432
+    databaseName: keycloak
+    username: keycloak
+    password: keycloak
+    superuserEnabled: true
+  storageClassName: storage # Valid only if externalDatabase is false
+  externalAccessEnabled: false
+
+keycloakRealm: []
+# - name: myrealm
+#   displayName: "My Realm"
+
+keycloakUser: []
+# - name: "myuser"
+#   firstName: "John"
+#   lastName: "Doe"
+#   email: "myuser@keycloak.org"
+#   password: "12345"
+#   realm: myrealm
+
+keycloakClient: []
+# - name: myclient
+#   realm: myrealm
+#   protocol: openid-connect
+#   rootUrl: https://www.keycloak.org/app/


### PR DESCRIPTION
keycloak-operator를 통해 keyclock 인스턴스 및 realm, user, client 생성을 수행하는 keycloak-resources 차트 추가합니다. realm, user, client는 https://www.keycloak.org/getting-started/getting-started-operator-kubernetes 예제만 고려해서 작성하였으며 다양한 변수 적용을 위해 추가 개발이 필요합니다.