### PR TITLE
keycloak-resources: remove namespace field

### DIFF
--- a/keycloak-resources/templates/keycloak.yaml
+++ b/keycloak-resources/templates/keycloak.yaml
@@ -2,7 +2,6 @@ apiVersion: keycloak.org/v1alpha1
 kind: Keycloak
 metadata:
   name: {{ .Values.keycloak.name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.keycloak.name }}
 spec:

--- a/keycloak-resources/templates/secret-database.yaml
+++ b/keycloak-resources/templates/secret-database.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: keycloak-db-secret
-    namespace: keycloak
 stringData:
     POSTGRES_DATABASE: "{{ .Values.keycloak.externalDatabase.databaseName }}"
     # MUST BE FQDN FOR ADDRESS


### PR DESCRIPTION
keycloak operator를 위한 자원 정의에서 명시적인 네임스페이스 정의를 제거하여 다른 네임스페이스 설치가 가능하도록 변경하였습니다.