### PR TITLE
cluster-autoscaler: add manangement rbac deploy only option

### DIFF
--- a/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-autoscaler
 description: cluster-autoscaler for cluster-api cloud provder
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.22.2"

--- a/cluster-autoscaler/templates/clusterrole.yaml
+++ b/cluster-autoscaler/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployMgmtRbacOnly.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -107,3 +108,4 @@ rules:
     - list
     - update
     - watch
+{{- end }}

--- a/cluster-autoscaler/templates/clusterrolebinding.yaml
+++ b/cluster-autoscaler/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployMgmtRbacOnly.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -23,3 +24,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "cluster-autoscaler.serviceAccountName" . }}
   namespace: {{ default .Release.Namespace .Values.namespace }}
+{{- end }}

--- a/cluster-autoscaler/templates/deployment.yaml
+++ b/cluster-autoscaler/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployMgmtRbacOnly.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,3 +72,4 @@ spec:
         secret:
           secretName: "{{ .Values.mgmtKubeconfigSecretName }}"
       {{- end }}
+{{- end }}

--- a/cluster-autoscaler/templates/rbac-for-mgmt-cluster-access.yaml
+++ b/cluster-autoscaler/templates/rbac-for-mgmt-cluster-access.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.deployMgmtRbacOnly.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-management
+  namespace: {{ .Values.deployMgmtRbacOnly.targetNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler-management
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: {{ .Values.deployMgmtRbacOnly.targetNamespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-management
+  namespace: {{ .Values.deployMgmtRbacOnly.targetNamespace }}
+rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    resources:
+    - machinedeployments
+    - machinedeployments/scale
+    - machines
+    - machinesets
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: {{ .Values.deployMgmtRbacOnly.targetNamespace }}
+{{- end }}

--- a/cluster-autoscaler/templates/service.yaml
+++ b/cluster-autoscaler/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployMgmtRbacOnly.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "cluster-autoscaler.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/cluster-autoscaler/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployMgmtRbacOnly.enabled }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -10,4 +11,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/values.yaml
@@ -7,6 +7,11 @@ separateMgmtClusterEnabled: false
 discoveryNamespace: default
 discoveryClusterName: workload-cluster
 
+# ONLY creating a service account credential in the management cluster
+deployMgmtRbacOnly:
+  enabled: false
+  targetNamespace: default
+
 # Secret name in the workload cluster, has management cluster kubeconfig to run against
 # Valid only when separateMgmtClusterEnabled is true
 mgmtKubeconfigSecretName: mgmt-kubeconfig


### PR DESCRIPTION
```
+--------+                           +------------+
|  mgmt   |                             |  workload  |
|               |    cloud-config  | ----------   |
|                |  < ----------     + autoscaler |
+--------+                          +------------+
```
워크로드 클러스터의 오토 스케일러가 MGMT 클러스터에 접근하여 machinedeploment, machineset 등의 자원을 수정하기 위해 필요한 RBAC 설정하는 부분을 추가하였습니다.

설정에 따라 대상 클러스터를 다르게 하여 배포합니다.
1. deployMgmtRbacOnly.enabled=true -> MGMT 클러스터에 설치
2. deployMgmtRbacOnly.enabled=false -> 워크로드 클러스터에 설치
