### PR TITLE
kubernetes-addons: add 'taco-storage' storageclass

### DIFF
--- a/kubernetes-addons/templates/storageclass.yaml
+++ b/kubernetes-addons/templates/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: taco-storage
+provisioner: ebs.csi.aws.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/kubernetes-addons/values.yaml
+++ b/kubernetes-addons/values.yaml
@@ -1,3 +1,6 @@
 cni:
   calico:
     enabled: true
+
+storageclass:
+  enabled: true


### PR DESCRIPTION
AWS EBS CSI 드라이버 설치 후 어플리케이션에서 이를 사용하기 위한 스토리지 클래스를 추가합니다.