### PR TITLE
cluster-api-aws: use unique key for the machinedeployment raw yaml

### DIFF
--- a/cluster-api-aws/artifacts/generate_worker_machines.py
+++ b/cluster-api-aws/artifacts/generate_worker_machines.py
@@ -59,7 +59,9 @@ def gen_machinedeployment_resource(subnets):
     machinedeployments = yaml.safe_load(open('md.raw.yaml', 'r'))
 
     for resource in machinedeployments:
-      machinedeployments[resource]['AWSMachineTemplate']['spec']['template']['spec']['subnet']=subnetd[resource]
+      # resource => "MD_NAME-[0-(NUMBER_OF_AZ - 1)]"
+      az_index = int(resource[-1])
+      machinedeployments[resource]['AWSMachineTemplate']['spec']['template']['spec']['subnet']=subnetd[az_index]
   except yaml.YAMLError as exc:
     print(exc)
   except TypeError as exc:

--- a/cluster-api-aws/templates/worker_machines/_md.yaml
+++ b/cluster-api-aws/templates/worker_machines/_md.yaml
@@ -11,7 +11,7 @@
 {{- $mdSubnet := .subnet }}
 {{- $spot := .spotInstance }}
 {{- range untilStep 0 $numAZ 1 }}
-{{ . }}:
+{{ $mdName }}-{{ . }}:
   MachineDeployment:
     apiVersion: {{ $envAll.Values.api.group.cluster }}/{{ $envAll.Values.api.version }}
     kind: MachineDeployment


### PR DESCRIPTION
machinedeployment (이하 md) 생성 중간 단계인 configmap내 데이터를 생성하는 과정에서 키를 0부터 (AZ-1)까지 단순 숫자를 사용하였기 때문에 2개 이상의 md를 정의하는 경우 키가 중복되어 마지막 md의 내용만 적용되는 문제를 발견해서 수정합니다.

정의한 md의 이름과 0~(AZ-1) 까지 숫자를 조합해서 키를 사용하도록 변경하였습니다. 또한, 키의 마지막 문자는 0~(AZ-1) 값을 가지고 각 AZ에 생성된 서브넷 정보가 저장된 subnet 리스트의 인덱스로 사용됩니다.