### PR TITLE
feature. remove node selector

### DIFF
--- a/tks-batch/values.yaml
+++ b/tks-batch/values.yaml
@@ -41,9 +41,6 @@ ingress:
 autoscaling:
   enabled: false
 
-nodeSelector:
-  taco-tks: enabled
-
 tolerations: []
 
 affinity: {}

--- a/tks-cluster-lcm/templates/deployment.yaml
+++ b/tks-cluster-lcm/templates/deployment.yaml
@@ -43,9 +43,6 @@ spec:
           env:
           - name: LOG_LEVEL
             value: DEBUG
-          envFrom:
-            - secretRef:
-                name: "github-tks-mgmt-token"
           args: [
             "-port", "{{ .Values.args.port }}",
             "-info-address", "{{ .Values.args.tksInfoAddress }}",

--- a/tks-cluster-lcm/values.yaml
+++ b/tks-cluster-lcm/values.yaml
@@ -72,9 +72,6 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
 
-nodeSelector:
-  taco-tks: enabled
-
 tolerations: []
 
 affinity: {}

--- a/tks-contract/values.yaml
+++ b/tks-contract/values.yaml
@@ -78,9 +78,6 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
 
-nodeSelector:
-  taco-tks: enabled
-
 tolerations: []
 
 affinity: {}

--- a/tks-info/values.yaml
+++ b/tks-info/values.yaml
@@ -75,9 +75,6 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
 
-nodeSelector:
-  taco-tks: enabled
-
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
tks-apis 의 node selector 를 제거 합니다.
초기 chart부터 taco-tks=enabled 라는 node selector 를 사용하였는데, 별다른 이유가 없다면 제거해도 무방하다고 생각합니다.
이로인해 releases 문서에 불필요한 step 이 필요합니다.