### PR TITLE
add non-downloadable upstream charts

### DIFF
--- a/keycloak/requirements.yaml
+++ b/keycloak/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: postgresql
-    version: 8.9.5
-    repository: https://charts.bitnami.com/bitnami
-    condition: keycloak.persistence.deployPostgres

--- a/kube-state-metrics/.helmignore
+++ b/kube-state-metrics/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kube-state-metrics/Chart.lock
+++ b/kube-state-metrics/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:14.870406+01:00"

--- a/kube-state-metrics/Chart.yaml
+++ b/kube-state-metrics/Chart.yaml
@@ -1,0 +1,26 @@
+annotations:
+  category: Analytics
+apiVersion: v2
+appVersion: 1.9.7
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/kube-state-metrics
+icon: https://bitnami.com/assets/stacks/kube-state-metrics/img/kube-state-metrics-stack-220x234.png
+keywords:
+  - prometheus
+  - kube-state-metrics
+  - monitoring
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: kube-state-metrics
+sources:
+  - https://github.com/bitnami/bitnami-docker-kube-state-metrics
+  - https://github.com/kubernetes/kube-state-metrics
+version: 1.1.3

--- a/kube-state-metrics/README.md
+++ b/kube-state-metrics/README.md
@@ -1,0 +1,221 @@
+# kube-state-metrics
+
+[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
+
+## TL;DR
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/kube-state-metrics
+```
+
+## Introduction
+
+This chart bootstraps [kube-state-metrics](https://github.com/bitnami/bitnami-docker-kube-state-metrics) on [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3.0-beta3+
+
+## Installing the Chart
+
+Add the `bitnami` charts repo to Helm:
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+```
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install my-release bitnami/kube-state-metrics
+```
+
+The command deploys kube-state-metrics on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` release:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the kube-state-metrics chart and their default values.
+
+| Parameter                                    | Description                                                                                                   | Default                                                    |
+|----------------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| `global.imageRegistry`                       | Global Docker image registry                                                                                  | `nil`                                                      |
+| `global.imagePullSecrets`                    | Global Docker registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods)    |
+| `global.storageClass`                        | Global storage class for dynamic provisioning                                                                 | `nil`                                                      |
+| `global.labels`                              | Additional labels to apply to all resources                                                                   | `{}`                                                       |
+| `nameOverride`                               | String to partially override `kube-state-metrics.name` template with a string (will prepend the release name) | `nil`                                                      |
+| `fullnameOverride`                           | String to fully override `kube-state-metrics.fullname` template with a string                                 | `nil`                                                      |
+| `rbac.create`                                | Whether to create & use RBAC resources or not                                                                 | `true`                                                     |
+| `rbac.apiVersion`                            | Version of the RBAC API                                                                                       | `v1beta1`                                                  |
+| `rbac.pspEnabled`                            | PodSecurityPolicy                                                                                             | `true`                                                     |
+| `serviceAccount.create`                      | Specify whether to create a ServiceAccount for kube-state-metrics                                             | `true`                                                     |
+| `serviceAccount.name`                        | The name of the ServiceAccount to create                                                                      | Generated using the `kube-state-metrics.fullname` template |
+| `image.registry`                             | kube-state-metrics image registry                                                                             | `docker.io`                                                |
+| `image.repository`                           | kube-state-metrics Image name                                                                                 | `bitnami/kube-state-metrics`                               |
+| `image.tag`                                  | kube-state-metrics Image tag                                                                                  | `{TAG_NAME}`                                               |
+| `image.pullPolicy`                           | kube-state-metrics image pull policy                                                                          | `IfNotPresent`                                             |
+| `image.pullSecrets`                          | Specify docker-registry secret names as an array                                                              | `[]` (does not add image pull secrets to deployed pods)    |
+| `extraArgs`                                  | Additional command line arguments to pass to kube-state-metrics                                               | `{}`                                                       |
+| `namespace`                                  | Comma-separated list of namespaces to be enabled. Defaults to all namespaces                                  | ``                                                         |
+| `collectors.certificatesigningrequests`      | Enable the `certificatesigningrequests` collector                                                             | `true`                                                     |
+| `collectors.configmaps`                      | Enable the `configmaps` collector                                                                             | `true`                                                     |
+| `collectors.cronjobs`                        | Enable the `cronjobs` collector                                                                               | `true`                                                     |
+| `collectors.daemonsets`                      | Enable the `daemonsets` collector                                                                             | `true`                                                     |
+| `collectors.deployments`                     | Enable the `deployments` collector                                                                            | `true`                                                     |
+| `collectors.endpoints`                       | Enable the `endpoints` collector                                                                              | `true`                                                     |
+| `collectors.horizontalpodautoscalers`        | Enable the `horizontalpodautoscalers` collector                                                               | `true`                                                     |
+| `collectors.ingresses`                       | Enable the `ingresses` collector                                                                              | `true`                                                     |
+| `collectors.jobs`                            | Enable the `jobs` collector                                                                                   | `true`                                                     |
+| `collectors.limitranges`                     | Enable the `limitranges` collector                                                                            | `true`                                                     |
+| `collectors.mutatingwebhookconfigurations`   | Enable the `mutatingwebhookconfigurations` collector                                                          | `true`                                                     |
+| `collectors.namespaces`                      | Enable the `namespaces` collector                                                                             | `true`                                                     |
+| `collectors.networkpolicies`                 | Enable the `networkpolicies` collector                                                                        | `true`                                                     |
+| `collectors.nodes`                           | Enable the `nodes` collector                                                                                  | `true`                                                     |
+| `collectors.persistentvolumeclaims`          | Enable the `persistentvolumeclaims` collector                                                                 | `true`                                                     |
+| `collectors.persistentvolumes`               | Enable the `persistentvolumes` collector                                                                      | `true`                                                     |
+| `collectors.poddisruptionbudgets`            | Enable the `poddisruptionbudgets` collector                                                                   | `true`                                                     |
+| `collectors.pods`                            | Enable the `pods` collector                                                                                   | `true`                                                     |
+| `collectors.replicasets`                     | Enable the `replicasets` collector                                                                            | `true`                                                     |
+| `collectors.replicationcontrollers`          | Enable the `replicationcontrollers` collector                                                                 | `true`                                                     |
+| `collectors.resourcequotas`                  | Enable the `resourcequotas` collector                                                                         | `true`                                                     |
+| `collectors.secrets`                         | Enable the `secrets` collector                                                                                | `true`                                                     |
+| `collectors.services`                        | Enable the `services` collector                                                                               | `true`                                                     |
+| `collectors.statefulsets`                    | Enable the `statefulsets` collector                                                                           | `true`                                                     |
+| `collectors.storageclasses`                  | Enable the `storageclasses` collector                                                                         | `true`                                                     |
+| `collectors.verticalpodautoscalers`          | Enable the `verticalpodautoscalers` collector                                                                 | `false`                                                    |
+| `collectors.validatingwebhookconfigurations` | Enable the `validatingwebhookconfigurations` collector                                                        | `false`                                                    |
+| `collectors.volumeattachments`               | Enable the `volumeattachments` collector                                                                      | `true`                                                     |
+| `securityContext.enabled`                    | Enable security context                                                                                       | `true`                                                     |
+| `securityContext.runAsUser`                  | User ID for the container                                                                                     | `1001`                                                     |
+| `securityContext.fsGroup`                    | Group ID for the container filesystem                                                                         | `1001`                                                     |
+| `service.type`                               | Kubernetes service type                                                                                       | `ClusterIP`                                                |
+| `service.port`                               | kube-state-metrics service port                                                                               | `8080`                                                     |
+| `service.clusterIP`                          | Specific cluster IP when service type is cluster IP. Use `None` for headless service                          | `nil`                                                      |
+| `service.nodePort`                           | Kubernetes Service nodePort                                                                                   | `nil`                                                      |
+| `service.loadBalancerIP`                     | `loadBalancerIP` if service type is `LoadBalancer`                                                            | `nil`                                                      |
+| `service.loadBalancerSourceRanges`           | Address that are allowed when svc is `LoadBalancer`                                                           | `[]`                                                       |
+| `service.annotations`                        | Additional annotations for kube-state-metrics service                                                         | `{}`                                                       |
+| `service.labels`                             | Additional labels for kube-state-metrics service                                                              | `{}`                                                       |
+| `hostNetwork`                                | Enable hostNetwork mode                                                                                       | `false`                                                    |
+| `priorityClassName`                          | Priority class assigned to the Pods                                                                           | `nil`                                                      |
+| `resources`                                  | Resource requests/limit                                                                                       | `{}`                                                       |
+| `replicaCount`                               | Desired number of controller pods                                                                             | `1`                                                        |
+| `podLabels`                                  | Pod labels                                                                                                    | `{}`                                                       |
+| `podAnnotations`                             | Pod annotations                                                                                               | `{}`                                                       |
+| `updateStrategy`                             | Allows setting of `RollingUpdate` strategy                                                                    | `{}`                                                       |
+| `minReadySeconds`                            | How many seconds a pod needs to be ready before killing the next, during update                               | `0`                                                        |
+| `podAffinityPreset`                          | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                           | `""`                                                       |
+| `podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                      | `soft`                                                     |
+| `nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                                                       |
+| `nodeAffinityPreset.key`                     | Node label key to match. Ignored if `affinity` is set.                                                        | `""`                                                       |
+| `nodeAffinityPreset.values`                  | Node label values to match. Ignored if `affinity` is set.                                                     | `[]`                                                       |
+| `affinity`                                   | Affinity for pod assignment                                                                                   | `{}` (evaluated as a template)                             |
+| `nodeSelector`                               | Node labels for pod assignment                                                                                | `{}` (evaluated as a template)                             |
+| `tolerations`                                | Tolerations for pod assignment                                                                                | `[]` (evaluated as a template)                             |
+| `livenessProbe.enabled`                      | Turn on and off liveness probe                                                                                | `true`                                                     |
+| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                                                      | `120`                                                      |
+| `livenessProbe.periodSeconds`                | How often to perform the probe                                                                                | `10`                                                       |
+| `livenessProbe.timeoutSeconds`               | When the probe times out                                                                                      | `5`                                                        |
+| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe                                                                    | `6`                                                        |
+| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe                                                                   | `1`                                                        |
+| `readinessProbe.enabled`                     | Turn on and off readiness probe                                                                               | `true`                                                     |
+| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                                                     | `30`                                                       |
+| `readinessProbe.periodSeconds`               | How often to perform the probe                                                                                | `10`                                                       |
+| `readinessProbe.timeoutSeconds`              | When the probe times out                                                                                      | `5`                                                        |
+| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe                                                                    | `6`                                                        |
+| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe                                                                   | `1`                                                        |
+| `serviceMonitor.enabled`                     | Creates a ServiceMonitor to monitor kube-state-metrics                                                        | `false`                                                    |
+| `serviceMonitor.namespace`                   | Namespace in which Prometheus is running                                                                      | `nil`                                                      |
+| `serviceMonitor.interval`                    | Scrape interval (use by default, falling back to Prometheus' default)                                         | `nil`                                                      |
+| `serviceMonitor.jobLabel`                    | The name of the label on the target service to use as the job name in prometheus.                             | `nil`                                                      |
+| `serviceMonitor.selector`                    | ServiceMonitor selector labels                                                                                | `[]`                                                       |
+| `serviceMonitor.honorLabels`                 | Honor metrics labels                                                                                          | `false`                                                    |
+| `serviceMonitor.relabelings`                 | ServiceMonitor relabelings                                                                                    | `[]`                                                       |
+| `serviceMonitor.metricRelabelings`           | ServiceMonitor metricRelabelings                                                                              | `[]`                                                       |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example the following command sets the `replicas` of the kube-state-metrics Pods to `2`.
+
+```bash
+$ helm install my-release --set replicas=2 bitnami/kube-state-metrics
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install my-release -f values.yaml bitnami/kube-state-metrics
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Production configuration
+
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
+
+- Increase the number of kube-state-metrics Pod replicas:
+
+```diff
+-   replicaCount: 1
++   replicaCount: 2
+```
+
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `affinity` parameter. Find more information about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+```bash
+$ helm upgrade my-release bitnami/kube-state-metrics
+```
+
+### To 1.1.0
+
+This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+### To 1.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/

--- a/kube-state-metrics/templates/NOTES.txt
+++ b/kube-state-metrics/templates/NOTES.txt
@@ -1,0 +1,36 @@
+** Please be patient while the chart is being deployed **
+
+Watch the kube-state-metrics Deployment status using the command:
+
+    kubectl get deploy -w --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }}
+
+kube-state-metrics can be accessed via port "{{ .Values.service.port }}" on the following DNS name from within your cluster:
+
+    {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access kube-state-metrics from outside the cluster execute the following commands:
+
+{{- if contains "LoadBalancer" .Values.service.type }}
+
+    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+    Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
+
+{{- $port:=.Values.service.port | toString }}
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    echo "URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+    echo "URL: http://127.0.0.1:9100/"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 9100:{{ .Values.service.port }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "URL: http://$NODE_IP:$NODE_PORT/"
+
+{{- end }}
+
+{{- include "kube-state-metrics.checkRollingTags" . }}

--- a/kube-state-metrics/templates/_helpers.tpl
+++ b/kube-state-metrics/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the appropriate apiVersion for PodSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-state-metrics.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper kube-state-metrics image name
+*/}}
+{{- define "kube-state-metrics.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "kube-state-metrics.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "kube-state-metrics.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- end -}}

--- a/kube-state-metrics/templates/clusterrole.yaml
+++ b/kube-state-metrics/templates/clusterrole.yaml
@@ -1,0 +1,176 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+rules:
+  {{- if .Values.collectors.certificatesigningrequests }}
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - certificatesigningrequests
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.configmaps }}
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.cronjobs }}
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.daemonsets }}
+  - apiGroups: ["extensions", "apps"]
+    resources:
+      - daemonsets
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.deployments }}
+  - apiGroups: ["extensions", "apps"]
+    resources:
+      - deployments
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.endpoints }}
+  - apiGroups: [""]
+    resources:
+      - endpoints
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.horizontalpodautoscalers }}
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.ingresses }}
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.jobs }}
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.limitranges }}
+  - apiGroups: [""]
+    resources:
+      - limitranges
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.mutatingwebhookconfigurations }}
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.namespaces }}
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.networkpolicies }}
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.nodes }}
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.persistentvolumeclaims }}
+  - apiGroups: [""]
+    resources:
+      - persistentvolumeclaims
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.persistentvolumes }}
+  - apiGroups: [""]
+    resources:
+      - persistentvolumes
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.poddisruptionbudgets }}
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.pods }}
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.replicasets }}
+  - apiGroups: ["extensions", "apps"]
+    resources:
+      - replicasets
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.replicationcontrollers }}
+  - apiGroups: [""]
+    resources:
+      - replicationcontrollers
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.resourcequotas }}
+  - apiGroups: [""]
+    resources:
+      - resourcequotas
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.secrets }}
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.services }}
+  - apiGroups: [""]
+    resources:
+      - services
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.statefulsets }}
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.storageclasses }}
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.verticalpodautoscalers }}
+  - apiGroups: ["autoscaling.k8s.io"]
+    resources:
+      - verticalpodautoscalers
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.validatingwebhookconfigurations }}
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - validatingwebhookconfigurations
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.volumeattachments }}
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - volumeattachments
+    verbs: ["list", "watch"]
+  {{- end }}
+{{- end }}

--- a/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "common.names.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kube-state-metrics.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/kube-state-metrics/templates/deployment.yaml
+++ b/kube-state-metrics/templates/deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicaCount }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  template:
+    metadata:
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      {{- include "kube-state-metrics.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      serviceAccountName: {{ template "kube-state-metrics.serviceAccountName" . }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kube-state-metrics
+          image: {{ template "kube-state-metrics.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- if .Values.collectors.certificatesigningrequests }}
+            - --collectors=certificatesigningrequests
+            {{- end }}
+            {{- if .Values.collectors.configmaps }}
+            - --collectors=configmaps
+            {{- end }}
+            {{- if .Values.collectors.cronjobs }}
+            - --collectors=cronjobs
+            {{- end }}
+            {{- if .Values.collectors.daemonsets }}
+            - --collectors=daemonsets
+            {{- end }}
+            {{- if .Values.collectors.deployments }}
+            - --collectors=deployments
+            {{- end }}
+            {{- if .Values.collectors.endpoints }}
+            - --collectors=endpoints
+            {{- end }}
+            {{- if .Values.collectors.horizontalpodautoscalers }}
+            - --collectors=horizontalpodautoscalers
+            {{- end }}
+            {{- if .Values.collectors.ingresses }}
+            - --collectors=ingresses
+            {{- end }}
+            {{- if .Values.collectors.jobs }}
+            - --collectors=jobs
+            {{- end }}
+            {{- if .Values.collectors.limitranges }}
+            - --collectors=limitranges
+            {{- end }}
+            {{- if .Values.collectors.mutatingwebhookconfigurations }}
+            - --collectors=mutatingwebhookconfigurations
+            {{- end }}
+            {{- if .Values.collectors.namespaces }}
+            - --collectors=namespaces
+            {{- end }}
+            {{- if .Values.collectors.networkpolicies }}
+            - --collectors=networkpolicies
+            {{- end }}
+            {{- if .Values.collectors.nodes }}
+            - --collectors=nodes
+            {{- end }}
+            {{- if .Values.collectors.persistentvolumeclaims }}
+            - --collectors=persistentvolumeclaims
+            {{- end }}
+            {{- if .Values.collectors.persistentvolumes }}
+            - --collectors=persistentvolumes
+            {{- end }}
+            {{- if .Values.collectors.poddisruptionbudgets }}
+            - --collectors=poddisruptionbudgets
+            {{- end }}
+            {{- if .Values.collectors.pods }}
+            - --collectors=pods
+            {{- end }}
+            {{- if .Values.collectors.replicasets }}
+            - --collectors=replicasets
+            {{- end }}
+            {{- if .Values.collectors.replicationcontrollers }}
+            - --collectors=replicationcontrollers
+            {{- end }}
+            {{- if .Values.collectors.resourcequotas }}
+            - --collectors=resourcequotas
+            {{- end }}
+            {{- if .Values.collectors.secrets }}
+            - --collectors=secrets
+            {{- end }}
+            {{- if .Values.collectors.services }}
+            - --collectors=services
+            {{- end }}
+            {{- if .Values.collectors.statefulsets }}
+            - --collectors=statefulsets
+            {{- end }}
+            {{- if .Values.collectors.storageclasses }}
+            - --collectors=storageclasses
+            {{- end }}
+            {{- if .Values.collectors.verticalpodautoscalers }}
+            - --collectors=verticalpodautoscalers
+            {{- end }}
+            {{- if .Values.collectors.validatingwebhookconfigurations }}
+            - --collectors=validatingwebhookconfigurations
+            {{- end }}
+            {{- if .Values.collectors.volumeattachments }}
+            - --collectors=volumeattachments
+            {{- end }}
+            {{- if .Values.namespace }}
+            - --namespace={{ .Values.namespace }}
+            {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}

--- a/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "common.names.fullname" . }}-psp
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames:
+      - {{ template "common.names.fullname" . }}
+{{- end }}

--- a/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "common.names.fullname" . }}-psp
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "common.names.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kube-state-metrics.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/kube-state-metrics/templates/psp.yaml
+++ b/kube-state-metrics/templates/psp.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  privileged: false
+  volumes:
+    - 'secret'
+  hostNetwork: {{ .Values.hostNetwork }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1001
+        max: 1001
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1001
+        max: 1001
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1001
+        max: 1001
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/kube-state-metrics/templates/service.yaml
+++ b/kube-state-metrics/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- if not .Values.serviceMonitor.enabled }}
+    prometheus.io/scrape: "true"
+    {{- end }}
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      {{- if and .Values.service.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/kube-state-metrics/templates/serviceaccount.yaml
+++ b/kube-state-metrics/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kube-state-metrics.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+{{- end }}

--- a/kube-state-metrics/templates/servicemonitor.yaml
+++ b/kube-state-metrics/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- range $key, $value := .Values.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if hasKey .Values.serviceMonitor "honorLabels" }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/kube-state-metrics/values-production.yaml
+++ b/kube-state-metrics/values-production.yaml
@@ -1,0 +1,298 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+global:
+  # imageRegistry: myRegistryName
+  # imagePullSecrets:
+  #   - myRegistryKeySecretName
+  # storageClass: myStorageClass
+
+  ## Additional labels to apply to all resources
+  labels: {}
+  #   foo: bar
+
+## String to partially override kube-state-metrics.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override kube-state-metrics.fullname template
+##
+# fullnameOverride:
+
+## Role Based Access
+## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  create: true
+
+  ## RBAC API version
+  ##
+  apiVersion: v1beta1
+
+  ## Podsecuritypolicy
+  ##
+  pspEnabled: true
+
+## Service account for kube-state-metrics to use.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the kube-state-metrics.fullname template
+  # name:
+
+## Bitnami kube-state-metrics image version
+## ref: https://hub.docker.com/r/bitnami/kube-state-metrics/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/kube-state-metrics
+  tag: 1.9.7-debian-10-r143
+
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## Additional command line arguments to pass to kube-state-metrics
+extraArgs: {}
+
+## Comma-separated list of namespaces to be enabled. Defaults to all namespaces
+# namespace: ""
+
+## Collectors to be enabled
+collectors:
+  certificatesigningrequests: true
+  configmaps: true
+  cronjobs: true
+  daemonsets: true
+  deployments: true
+  endpoints: true
+  horizontalpodautoscalers: true
+  ingresses: true
+  jobs: true
+  limitranges: true
+  mutatingwebhookconfigurations: true
+  namespaces: true
+  networkpolicies: true
+  nodes: true
+  persistentvolumeclaims: true
+  persistentvolumes: true
+  poddisruptionbudgets: true
+  pods: true
+  replicasets: true
+  replicationcontrollers: true
+  resourcequotas: true
+  secrets: true
+  services: true
+  statefulsets: true
+  storageclasses: true
+  verticalpodautoscalers: false
+  validatingwebhookconfigurations: false
+  volumeattachments: true
+
+## SecurityContext configuration
+##
+securityContext:
+  enabled: true
+  runAsUser: 1001
+  fsGroup: 1001
+
+## kube-state-metrics Service
+##
+service:
+  ## Kubernetes service type and port number
+  ##
+  type: ClusterIP
+  port: 8080
+  # clusterIP: None
+
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort: 30080
+
+  ## Set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  # loadBalancerIP:
+
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  # loadBalancerSourceRanges:
+  # - 10.10.10.0/24
+
+  ## Provide any additional service annotations
+  ##
+  annotations: {}
+
+  ## Provide any additional service labels
+  ##
+  labels: {}
+
+# Enable hostNetwork mode
+hostNetwork: false
+
+## Priority class assigned to the Pods
+##
+priorityClassName: ""
+
+## Resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Number of replicas
+##
+replicaCount: 2
+
+## Pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## updateStrategy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+##
+updateStrategy: {}
+
+## minReadySeconds to avoid killing pods before we are ready
+##
+minReadySeconds: 0
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## ServiceMonitor configuration
+##
+serviceMonitor:
+  enabled: false
+  ## Namespace in which Prometheus is running
+  ##
+  # namespace: monitoring
+
+  ## The name of the label on the target service to use as the job name in prometheus
+  # jobLabel:
+
+  ## Interval at which metrics should be scraped.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # interval: 10s
+
+  ## Timeout after which the scrape is ended
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # scrapeTimeout: 10s
+
+  ## ServiceMonitor selector labels
+  ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+  ##
+  # selector:
+  #   prometheus: my-prometheus
+
+  ## Honor metric labels
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # honorLabels: false
+
+  ## Relabeling (before scrape)
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # relabelings: []
+
+  ## Metric relabeling
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # metricRelabelings: []

--- a/kube-state-metrics/values.yaml
+++ b/kube-state-metrics/values.yaml
@@ -1,0 +1,298 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+global:
+  # imageRegistry: myRegistryName
+  # imagePullSecrets:
+  #   - myRegistryKeySecretName
+  # storageClass: myStorageClass
+
+  ## Additional labels to apply to all resources
+  labels: {}
+  #   foo: bar
+
+## String to partially override kube-state-metrics.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override kube-state-metrics.fullname template
+##
+# fullnameOverride:
+
+## Role Based Access
+## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  create: true
+
+  ## RBAC API version
+  ##
+  apiVersion: v1beta1
+
+  ## Podsecuritypolicy
+  ##
+  pspEnabled: true
+
+## Service account for kube-state-metrics to use.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the kube-state-metrics.fullname template
+  # name:
+
+## Bitnami kube-state-metrics image version
+## ref: https://hub.docker.com/r/bitnami/kube-state-metrics/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/kube-state-metrics
+  tag: 1.9.7-debian-10-r143
+
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## Additional command line arguments to pass to kube-state-metrics
+extraArgs: {}
+
+## Comma-separated list of namespaces to be enabled. Defaults to all namespaces
+# namespace: ""
+
+## Collectors to be enabled
+collectors:
+  certificatesigningrequests: true
+  configmaps: true
+  cronjobs: true
+  daemonsets: true
+  deployments: true
+  endpoints: true
+  horizontalpodautoscalers: true
+  ingresses: true
+  jobs: true
+  limitranges: true
+  mutatingwebhookconfigurations: true
+  namespaces: true
+  networkpolicies: true
+  nodes: true
+  persistentvolumeclaims: true
+  persistentvolumes: true
+  poddisruptionbudgets: true
+  pods: true
+  replicasets: true
+  replicationcontrollers: true
+  resourcequotas: true
+  secrets: true
+  services: true
+  statefulsets: true
+  storageclasses: true
+  verticalpodautoscalers: false
+  validatingwebhookconfigurations: false
+  volumeattachments: true
+
+## SecurityContext configuration
+##
+securityContext:
+  enabled: true
+  runAsUser: 1001
+  fsGroup: 1001
+
+## kube-state-metrics Service
+##
+service:
+  ## Kubernetes service type and port number
+  ##
+  type: ClusterIP
+  port: 8080
+  # clusterIP: None
+
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort: 30080
+
+  ## Set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  # loadBalancerIP:
+
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  # loadBalancerSourceRanges:
+  # - 10.10.10.0/24
+
+  ## Provide any additional service annotations
+  ##
+  annotations: {}
+
+  ## Provide any additional service labels
+  ##
+  labels: {}
+
+# Enable hostNetwork mode
+hostNetwork: false
+
+## Priority class assigned to the Pods
+##
+priorityClassName: ""
+
+## Resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Number of replicas
+##
+replicaCount: 1
+
+## Pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## updateStrategy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+##
+updateStrategy: {}
+
+## minReadySeconds to avoid killing pods before we are ready
+##
+minReadySeconds: 0
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## ServiceMonitor configuration
+##
+serviceMonitor:
+  enabled: false
+  ## Namespace in which Prometheus is running
+  ##
+  # namespace: monitoring
+
+  ## The name of the label on the target service to use as the job name in prometheus
+  # jobLabel:
+
+  ## Interval at which metrics should be scraped.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # interval: 10s
+
+  ## Timeout after which the scrape is ended
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # scrapeTimeout: 10s
+
+  ## ServiceMonitor selector labels
+  ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+  ##
+  # selector:
+  #   prometheus: my-prometheus
+
+  ## Honor metric labels
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # honorLabels: false
+
+  ## Relabeling (before scrape)
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # relabelings: []
+
+  ## Metric relabeling
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # metricRelabelings: []

--- a/minio/.helmignore
+++ b/minio/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/minio/Chart.lock
+++ b/minio/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.5.2
+digest: sha256:7b5a8ece9b57d70ef47eb7ed27e6f66b059fb0fc1f2ca59a15bb495e32366690
+generated: "2021-05-22T23:11:53.116325412Z"

--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,0 +1,28 @@
+annotations:
+  category: Infrastructure
+apiVersion: v2
+appVersion: 2021.6.14
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+description: Bitnami Object Storage based on MinIO(R) is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/minio
+icon: https://bitnami.com/assets/stacks/minio/img/minio-stack-220x234.png
+keywords:
+  - minio
+  - storage
+  - object-storage
+  - s3
+  - cluster
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: minio
+sources:
+  - https://github.com/bitnami/bitnami-docker-minio
+  - https://min.io
+version: 6.8.3

--- a/minio/README.md
+++ b/minio/README.md
@@ -1,0 +1,472 @@
+# Bitnami Object Storage Helm Chart based on MinIO&reg;
+
+[MinIO&reg;](https://min.io) is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
+
+Disclaimer: All software products, projects and company names are trademark&trade; or registered&reg; trademarks of their respective holders, and use of them does not imply any affiliation or endorsement. This software is licensed to you subject to one or more open source licenses and VMware provides the software on an AS-IS basis. MinIO&reg; is a registered trademark of the MinIO, Inc in the US and other countries. Bitnami is not affiliated, associated, authorized, endorsed by, or in any way officially connected with MinIO Inc.
+
+## TL;DR
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/minio
+```
+
+## Introduction
+
+This chart bootstraps a [MinIO&reg;](https://github.com/bitnami/bitnami-docker-minio) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3.1.0
+- PV provisioner support in the underlying infrastructure
+- ReadWriteMany volumes for deployment scaling
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/minio
+```
+
+These commands deploy MinIO&reg; on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the MinIO&reg; chart and their their default values per section/component:
+
+### Global parameters
+
+| Parameter                      | Description                                                                                              | Default                                                 |
+|--------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`         | Global Docker image registry                                                                             | `nil`                                                   |
+| `global.imagePullSecrets`      | Global Docker registry secret names as an array                                                          | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`          | Global storage class for dynamic provisioning                                                            | `nil`                                                   |
+| `global.minio.existingSecret`  | Global MinIO&reg; credentials (overrides `accessKey.password` `secretKey.password` and `existingSecret`) | `{}`                                                    |
+
+### Common parameters
+
+| Parameter           | Description                                                          | Default                        |
+|---------------------|----------------------------------------------------------------------|--------------------------------|
+| `nameOverride`      | String to partially override common.names.fullname                   | `nil`                          |
+| `fullnameOverride`  | String to fully override common.names.fullname                       | `nil`                          |
+| `commonLabels`      | Labels to add to all deployed objects                                | `{}`                           |
+| `commonAnnotations` | Annotations to add to all deployed objects                           | `{}`                           |
+| `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
+| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
+
+### MinIO&reg; parameters
+
+| Parameter                         | Description                                                                                              | Default                                                 |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                  | MinIO&reg; image registry                                                                                | `docker.io`                                             |
+| `image.repository`                | MinIO&reg; image name                                                                                    | `bitnami/minio`                                         |
+| `image.tag`                       | MinIO&reg; image tag                                                                                     | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                | Image pull policy                                                                                        | `IfNotPresent`                                          |
+| `image.pullSecrets`               | Specify docker-registry secret names as an array                                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                     | Specify if debug logs should be enabled                                                                  | `false`                                                 |
+| `clientImage.registry`            | MinIO&reg; Client image registry                                                                         | `docker.io`                                             |
+| `clientImage.repository`          | MinIO&reg; Client image name                                                                             | `bitnami/minio-client`                                  |
+| `clientImage.tag`                 | MinIO&reg; Client image tag                                                                              | `{TAG_NAME}`                                            |
+| `mode`                            | MinIO&reg; server mode (`standalone` or `distributed`)                                                   | `standalone`                                            |
+| `accessKey.password`              | MinIO&reg; Access Key. Ignored if existing secret is provided.                                           | _random 10 character alphanumeric string_               |
+| `accessKey.forcePassword`         | Force users to specify an Access Key                                                                     | `false`                                                 |
+| `secretKey.password`              | MinIO&reg; Secret Key. Ignored if existing secret is provided.                                           | _random 40 character alphanumeric string_               |
+| `secretKey.forcePassword`         | Force users to specify an Secret Key                                                                     | `false`                                                 |
+| `existingSecret`                  | Existing secret with MinIO&reg; credentials                                                              | `nil`                                                   |
+| `useCredentialsFile`              | Have the secret mounted as a file instead of env vars                                                    | `false`                                                 |
+| `forceNewKeys`                    | Force admin credentials (access and secret key) to be reconfigured every time they change in the secrets | `false`                                                 |
+| `tls.enabled`                     | Enable tls in front of the container                                                                     | `true`                                                  |
+| `tls.secretName`                  | The name of the secret containing the certificates and key.                                              | `nil`                                                   |
+| `tls.mountPath`                   | The mount path where the secret will be located.                                                         | `nil`                                                   |
+| `defaultBuckets`                  | Comma, semi-colon or space separated list of buckets to create (only in standalone mode)                 | `nil`                                                   |
+| `disableWebUI`                    | Disable MinIO&reg; Web UI                                                                                | `false`                                                 |
+| `command`                         | Default container command (useful when using custom images)                                              | `{}`                                                    |
+| `args`                            | Default container args (useful when using custom images)                                                 | `nil`                                                   |
+| `extraEnv`                        | Extra environment variables to be set on MinIO&reg; container                                            | `{}`                                                    |
+| `extraEnvVarsCM`                  | Name of existing ConfigMap containing extra env vars                                                     | `nil`                                                   |
+| `extraEnvVarsSecret`              | Name of existing Secret containing extra env vars                                                        | `nil`                                                   |
+
+### MinIO&reg; deployment/statefulset parameters
+
+| Parameter                         | Description                                                                               | Default                        |
+|-----------------------------------|-------------------------------------------------------------------------------------------|--------------------------------|
+| `schedulerName`                   | Specifies the schedulerName, if it's nil uses kube-scheduler                              | `nil`                          |
+| `statefulset.replicaCount`        | Number of pods per zone (only for MinIO&reg; distributed mode). Should be even and `>= 4` | `4`                            |
+| `statefulset.zones`               | Number of zones (only for MinIO&reg; distributed mode)                                    | `1`                            |
+| `statefulset.drivesPerNode`       | Number of drives per node (only for MinIO&reg; distributed mode)                          | `1`                            |
+| `statefulset.updateStrategy`      | Statefulset update strategy policy                                                        | `RollingUpdate`                |
+| `statefulset.podManagementPolicy` | Statefulset pods management policy                                                        | `Parallel`                     |
+| `deployment.updateStrategy`       | Deployment update strategy policy                                                         | `Recreate`                     |
+| `securityContext.enabled`         | Enable security context                                                                   | `true`                         |
+| `securityContext.fsGroup`         | Group ID for the container                                                                | `1001`                         |
+| `securityContext.runAsUser`       | User ID for the container                                                                 | `1001`                         |
+| `securityContext.runAsNonRoot`    | Avoid running as root User                                                                | `true`                         |
+| `containerPort`                   | MinIO(R) container port to open                                                           | `9000`                         |
+| `resources.limits`                | The resources limits for the MinIO&reg; container                                         | `{}`                           |
+| `resources.requests`              | The requested resources for the MinIO&reg; container                                      | `{}`                           |
+| `livenessProbe`                   | Liveness probe configuration for MinIO&reg;                                               | Check `values.yaml` file       |
+| `readinessProbe`                  | Readiness probe configuration for MinIO&reg;                                              | Check `values.yaml` file       |
+| `startupProbe`                    | Startup probe configuration for MinIO&reg;                                                | Check `values.yaml` file       |
+| `customLivenessProbe`             | Override default liveness probe                                                           | `nil`                          |
+| `customReadinessProbe`            | Override default readiness probe                                                          | `nil`                          |
+| `customStartupProbe`              | Override default startup probe                                                            | `nil`                          |
+| `hostAliases`                     | MinIO&reg; pod host aliases                                                               | `[]`                           |
+| `podLabels`                       | Extra labels for MinIO&reg; pods                                                          | `{}`                           |
+| `podAnnotations`                  | Annotations for MinIO&reg; pods                                                           | `{}`                           |
+| `podAffinityPreset`               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
+| `podAntiAffinityPreset`           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
+| `nodeAffinityPreset.type`         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
+| `nodeAffinityPreset.key`          | Node label key to match. Ignored if `affinity` is set.                                    | `""`                           |
+| `nodeAffinityPreset.values`       | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
+| `affinity`                        | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
+| `nodeSelector`                    | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
+| `tolerations`                     | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
+| `extraVolumeMounts`               | Optionally specify extra list of additional volumeMounts for MinIO&reg; container(s)      | `[]`                           |
+| `extraVolumes`                    | Optionally specify extra list of additional volumes for MinIO&reg; pods                   | `[]`                           |
+| `initContainers`                  | Add additional init containers to the MinIO&reg; pods                                     | `{}` (evaluated as a template) |
+| `sidecars`                        | Add additional sidecar containers to the MinIO&reg; pods                                  | `{}` (evaluated as a template) |
+
+### Exposure parameters
+
+| Parameter                          | Description                                                                       | Default                        |
+|------------------------------------|-----------------------------------------------------------------------------------|--------------------------------|
+| `service.type`                     | Kubernetes service type                                                           | `ClusterIP`                    |
+| `service.port`                     | MinIO&reg; service port                                                           | `9000`                         |
+| `service.nodePort`                 | Port to bind to for NodePort service type                                         | `nil`                          |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                              | `Cluster`                      |
+| `service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                  | `nil`                          |
+| `service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                             | `[]`                           |
+| `service.annotations`              | Annotations for MinIO&reg; service                                                | `{}` (evaluated as a template) |
+| `ingress.enabled`                  | Enable ingress controller resource                                                | `false`                        |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                     | ``                             |
+| `ingress.path`                     | Ingress path                                                                      | `/`                            |
+| `ingress.pathType`                 | Ingress path type                                                                 | `ImplementationSpecific`       |
+| `ingress.certManager`              | Add annotations for cert-manager                                                  | `false`                        |
+| `ingress.hostname`                 | Default host for the ingress resource                                             | `minio.local`                  |
+| `ingress.tls`                      | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter | `false`                        |
+| `ingress.annotations`              | Ingress annotations                                                               | `{}` (evaluated as a template) |
+| `ingress.extraPaths`               | Any additional paths that may need to be added to the ingress under the main host | `[]`                           |
+| `ingress.extraHosts[0].name`       | Additional hostnames to be covered                                                | `nil`                          |
+| `ingress.extraHosts[0].path`       | Additional hostnames to be covered                                                | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered                          | `nil`                          |
+| `ingress.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered                          | `nil`                          |
+| `ingress.secrets[0].name`          | TLS Secret Name                                                                   | `nil`                          |
+| `ingress.secrets[0].certificate`   | TLS Secret Certificate                                                            | `nil`                          |
+| `ingress.secrets[0].key`           | TLS Secret Key                                                                    | `nil`                          |
+| `ingress.servicePort`              | Service port to be used                                                           | `http`                         |
+| `networkPolicy.enabled`            | Enable the default NetworkPolicy policy                                           | `false`                        |
+| `networkPolicy.allowExternal`      | Don't require client label for connections                                        | `true`                         |
+
+### Persistence parameters
+
+| Parameter                          | Description                                                                        | Default                        |
+|------------------------------------|------------------------------------------------------------------------------------|--------------------------------|
+| `persistence.enabled`              | Enable MinIO&reg; data persistence using PVC                                       | `true`                         |
+| `persistence.storageClass`         | PVC Storage Class for MinIO&reg; data volume                                       | `nil`                          |
+| `persistence.mountPath`            | Path to mount the volume at                                                        | `/data`                        |
+| `persistence.accessModes`          | PVC Access Modes for MinIO&reg; data volume                                        | `[ReadWriteOnce]`              |
+| `persistence.size`                 | PVC Storage Request for MinIO&reg; data volume                                     | `8Gi`                          |
+| `persistence.selector`             | Selector to match an existing Persistent Volume                                    | `{}`(evaluated as a template)  |
+| `persistence.annotations`          | Annotations for the PVC                                                            | `{}`(evaluated as a template)  |
+| `persistence.existingClaim`        | Name of an existing PVC to use (only in "standalone" mode)                         | `nil`                          |
+
+### Volume Permissions parameters
+
+| Parameter                              | Description                                                                                                          | Default                                                 |
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                                                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                     | `docker.io`                                             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                         | `bitnami/bitnami-shell`                                 |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `"10"`                                                  |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                  | `Always`                                                |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods) |
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                   | `{}`                                                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                 | `{}`                                                    |
+
+### RBAC parameters
+
+| Parameter               | Description                                                 | Default                                              |
+|-------------------------|-------------------------------------------------------------|------------------------------------------------------|
+| `serviceAccount.create` | Enable the creation of a ServiceAccount for MinIO&reg; pods | `true`                                               |
+| `serviceAccount.name`   | Name of the created ServiceAccount                          | Generated using the `common.names.fullname` template |
+
+### Other parameters
+
+| Parameter               | Description                                                    | Default |
+|-------------------------|----------------------------------------------------------------|---------|
+| `pdb.create`            | Enable/disable a Pod Disruption Budget creation                | `false` |
+| `pdb.minAvailable`      | Minimum number/percentage of pods that should remain scheduled | `1`     |
+| `pdb.maxUnavailable`    | Maximum number/percentage of pods that may be made unavailable | `nil`   |
+
+### Metrics parameters
+
+| Parameter                                 | Description                                                                         | Default                                                      |
+|-------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.prometheusAuthType`              | Authentication mode for Prometheus (`jwt` or `public`)                              | `public`                                                     |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator        | `false`                                                      |
+| `metrics.serviceMonitor.path`             | HTTP path to scrape for metrics                                                     | `/minio/v2/metrics/cluster`                                  |
+| `metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                            | `nil`                                                        |
+| `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                         | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                 | `nil`                                                        |
+| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                           | `nil`                                                        |
+| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.           | `false`                                                      |
+| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator          | `{}`                                                         |
+| `metrics.serviceMonitor.release`          | Used to pass Labels release that sometimes should be custom for Prometheus Operator | `nil`                                                        |
+
+### Gateway parameters
+
+| Parameter                                 | Description                                                                         | Default                                                      |
+|-------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `gateway.enabled`                         | Use MinIO&reg; as Gateway for other storage systems                                 | `false`                                                      |
+| `gateway.type`                            | Gateway type. Supported types are: `azure`, `gcs`, `nas`, `s3`                      | `s3`                                                         |
+| `gateway.replicaCount`                    | Number of MinIO&reg; Gateway replicas                                               | `4`                                                          |
+| `gateway.auth.azure.accessKey`            | Access Key to access MinIO using Azure Gateway                                      | _random 10 character alphanumeric string_                    |
+| `gateway.auth.azure.secretKey`            | Secret Key to access MinIO using Azure Gateway                                      | _random 40 character alphanumeric string_                    |
+| `gateway.auth.azure.storageAccountName`   | Azure Storage Account Name to use to access Azure Blob Storage                      | `nil`                                                        |
+| `gateway.auth.azure.storageAccountKey`    | Azure Storage Account Key to use to access Azure Blob Storage                       | `nil`                                                        |
+| `gateway.auth.gcs.accessKey`              | Access Key to access MinIO using GCS Gateway                                        | _random 10 character alphanumeric string_                    |
+| `gateway.auth.gcs.secretKey`              | Secret Key to access MinIO using GCS Gateway                                        | _random 40 character alphanumeric string_                    |
+| `gateway.auth.gcs.keyJSON`                | Service Account key to access GCS                                                   | `nil`                                                        |
+| `gateway.auth.gcs.projectID`              | GCP Project ID to use                                                               | `nil`                                                        |
+| `gateway.auth.nas.accessKey`              | Access Key to access MinIO using NAS Gateway                                        | _random 10 character alphanumeric string_                    |
+| `gateway.auth.nas.secretKey`              | Secret Key to access MinIO using NAS Gateway                                        | _random 40 character alphanumeric string_                    |
+| `gateway.auth.s3.serviceEndpoint`         | AWS S3 endpoint                                                                     | `https://s3.amazonaws.com`                                   |
+| `gateway.auth.s3.accessKey`               | Access Key to use to access AWS S3                                                  | `nil`                                                        |
+| `gateway.auth.s3.secretKey`               | Secret Key to use to access AWS S3                                                  | `nil`                                                        |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install my-release \
+  --set accessKey.password=minio-access-key \
+  --set secretKey.password=minio-secret-key \
+    bitnami/minio
+```
+
+The above command sets the MinIO&reg; Server access key and secret key to `minio-access-key` and `minio-secret-key`, respectively.
+
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install my-release -f values.yaml bitnami/minio
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Distributed mode
+
+By default, this chart provisions a MinIO&reg; server in standalone mode. You can start MinIO&reg; server in [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide) with the following parameter: `mode=distributed`
+
+This chart bootstrap MinIO&reg; server in distributed mode with 4 nodes by default. You can change the number of nodes using the `statefulset.replicaCount` parameter. For instance, you can deploy the chart with 8 nodes using the following parameters:
+
+```console
+mode=distributed
+statefulset.replicaCount=8
+```
+
+You can also bootstrap MinIO&reg; server in distributed mode in several zones, and using multiple drives per node. For instance, you can deploy the chart with 2 nodes per zone on 2 zones, using 2 drives per node:
+
+```console
+mode=distributed
+statefulset.replicaCount=2
+statefulset.zones=2
+statefulset.drivesPerNode=2
+```
+
+> Note: The total number of drives should be multiple of 4 to guarantee erasure coding. Please set a combination of nodes, and drives per node that match this condition.
+
+### Prometheus exporter
+
+MinIO&reg; exports Prometheus metrics at `/minio/v2/metrics/cluster`. To allow Prometheus collecting your MinIO&reg; metrics, modify the `values.yaml` adding the corresponding annotations:
+
+```diff
+- podAnnotations: {}
++ podAnnotations:
++   prometheus.io/scrape: "true"
++   prometheus.io/path: "/minio/v2/metrics/cluster"
++   prometheus.io/port: "9000"
+```
+
+> Find more information about MinIO&reg; metrics at https://docs.min.io/docs/how-to-monitor-minio-using-prometheus.html
+
+## Persistence
+
+The [Bitnami Object Storage based on MinIO&reg;](https://github.com/bitnami/bitnami-docker-minio) image stores data at the `/data` path of the container.
+
+The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
+
+### Adjust permissions of persistent volume mountpoint
+
+As the image run as non-root by default, it is necessary to adjust the ownership of the persistent volume so that the container can write data into it.
+
+By default, the chart is configured to use Kubernetes Security Context to automatically change the ownership of the volume. However, this feature does not work in all Kubernetes distributions.
+As an alternative, this chart supports using an initContainer to change the ownership of the volume before mounting it in the final destination.
+
+You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
+
+### Ingress
+
+This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://kubeapps.com/charts/stable/traefik) you can utilize the ingress controller to serve your MinIO&reg; server.
+
+To enable ingress integration, please set `ingress.enabled` to `true`, and `disableWebUI` to `false`.
+
+#### Hosts
+
+Most likely you will only want to have one hostname that maps to this MinIO&reg; installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts.
+
+For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
+
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
+
+#### TLS
+
+This chart will facilitate the creation of TLS secrets for use with the ingress controller, however, this is not required. There are four common use cases:
+
+- Helm generates/manages certificate secrets based on the parameters.
+- User generates/manages certificates separately.
+- Helm creates self-signed certificates and generates/manages certificate secrets.
+- An additional tool (like [cert-manager](https://github.com/jetstack/cert-manager/)) manages the secrets for the application.
+
+In the first two cases, it's needed a certificate and a key. Files are expected in PEM format.
+
+- If you are going to use Helm to manage the certificates based on the parameters, please copy these values into the `certificate` and `key` values for a given `ingress.secrets` entry.
+- In case you are going to manage TLS secrets separately, please know that you must create a TLS secret with name *INGRESS_HOSTNAME-tls* (where *INGRESS_HOSTNAME* is a placeholder to be replaced with the hostname you set using the `ingress.hostname` parameter).
+- To use self-signed certificates created by Helm, set `ingress.tls` to `true`, and `ingress.certManager` to `false`.
+- If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.certManager` boolean to `true` to enable the corresponding annotations for cert-manager.
+
+### MinIO&reg; Gateway
+
+MinIO&reg; can be configured as a Gateway for other other storage systems. Currently this chart supports to setup MinIO&reg; as a Gateway for the storage systems below:
+
+- [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/)
+- [GCS](https://cloud.google.com/storage)
+- NAS: Network Attached Storage
+- [AWS S3](https://aws.amazon.com/s3/)
+
+The enable this feature, install the chart setting `gateway.enabled` to `true`. You can choose the Gateway type setting the `gateway.type` parameter. For instance, to install the chart as a S3 Gateway, install the chart the using the following parameters:
+
+```console
+gateway.enabled=true
+gateway.replicaCount=4
+gateway.type=s3
+gateway.auth.s3.serviceEndpoint=https://s3.amazonaws.com
+gateway.auth.s3.accessKey=S3_ACCESS_KEY
+gateway.auth.s3.secretKey=S3_SECRET_KEY
+```
+
+> Note: remember to replace the S3_ACCESS_KEY and S3_SECRET_KEY placeholders with your actual S3 access & secret keys.
+
+Find all the available parameters to configure MinIO&reg; as a Gateway in the [Gateway parameters section](#gateway-parameters).
+
+> Note: when using MinIO&reg; as a NAS Gateway, you need ReadWriteMany PVs to deploy multiple MinIO&reg; instances. Ensure you K8s cluster supports this kind of cluster, and install the chart setting `persistence.accessModes[0]` to `ReadWriteMany` to do so.
+
+### Adding extra environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnv` property.
+
+```yaml
+extraEnv:
+  - name: MINNIO_LOG_LEVEL
+    value: DEBUG
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Sidecars and Init Containers
+
+If you have a need for additional containers to run within the same pod as the MinIO&reg; app (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+       containerPort: 1234
+```
+
+Similarly, you can add extra init containers using the `initContainers` parameter.
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+```
+
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `affinity` parameter. Find more information about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
+### Deploying extra resources
+
+There are cases where you may want to deploy extra objects, such a ConfigMap containing your app's configuration or some extra deployment with a micro service used by your app. For covering this case, the chart allows adding the full specification of other objects using the `extraDeploy` parameter.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 5.0.0
+
+This version standardizes the way of defining Ingress rules. When configuring a single hostname for the Ingress rule, set the `ingress.hostname` value. When defining more than one, set the `ingress.extraHosts` array. Apart from this case, no issues are expected to appear when upgrading.
+
+### To 4.1.0
+
+This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+### To 4.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/

--- a/minio/ci/values-gateway.yaml
+++ b/minio/ci/values-gateway.yaml
@@ -1,0 +1,8 @@
+gateway:
+  enabled: true
+  type: s3
+  auth:
+    s3:
+      serviceEndpoint: https://s3.amazonaws.com
+      accessKey: LoremIpsum
+      secretKey: dolorSitAmet

--- a/minio/ci/values-production.yaml
+++ b/minio/ci/values-production.yaml
@@ -1,0 +1,29 @@
+# Test values file for generating all of the yaml and check that
+# the rendering is correct
+
+volumePermissions:
+  enabled: true
+
+mode: distributed
+useCredentialsFile: true
+disableWebUI: false
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/minio/prometheus/metric"
+  prometheus.io/port: "9000"
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+ingress:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  allowExternal: false
+
+pdb:
+  create: true

--- a/minio/templates/NOTES.txt
+++ b/minio/templates/NOTES.txt
@@ -1,0 +1,86 @@
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.gateway.enabled }}
+MinIO(R) deployed as a {{ upper .Values.gateway.type }} Gateway
+{{- end }}
+
+MinIO(R) can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
+
+   {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+
+To get your credentials run:
+
+   export ACCESS_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.secretName" . }} -o jsonpath="{.data.access-key}" | base64 --decode)
+   export SECRET_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.secretName" . }} -o jsonpath="{.data.secret-key}" | base64 --decode)
+
+To connect to your MinIO(R) server using a client:
+
+- Run a MinIO(R) Client pod and append the desired command (e.g. 'admin info'):
+
+   kubectl run --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-client \
+     --rm --tty -i --restart='Never' \
+     --env MINIO_SERVER_ACCESS_KEY=$ACCESS_KEY \
+     --env MINIO_SERVER_SECRET_KEY=$SECRET_KEY \
+     --env MINIO_SERVER_HOST={{ include "common.names.fullname" . }} \
+     {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+     --labels="{{ include "common.names.fullname" . }}-client=true" \
+     {{- end }}
+     --image {{ template "minio.clientImage" . }} -- admin info minio
+
+{{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+
+   NOTE: Since NetworkPolicy is enabled, only pods with label
+   "{{ template "common.names.fullname" . }}-client=true" will be able to connect to MinIO(R).
+
+{{- end }}
+{{- if or .Values.gateway.enabled (not .Values.disableWebUI) }}
+
+To access the MinIO(R) web UI:
+
+- Get the MinIO(R) URL:
+
+{{- if .Values.ingress.enabled }}
+
+   You should be able to access your new MinIO(R) web UI through
+
+   {{ if .Values.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.ingress.hostname }}/minio/
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
+
+   {{- $port:=.Values.service.port | toString }}
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+   echo "MinIO(R) web URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/minio"
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+   echo "MinIO(R) web URL: http://127.0.0.1:9000/minio"
+   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 9000:{{ .Values.service.port }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+   echo "MinIO(R) web URL: http://$NODE_IP:$NODE_PORT/minio"
+
+{{- end }}
+{{- else }}
+
+   WARN: MinIO(R) Web UI is disabled.
+{{- end }}
+
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.clientImage }}
+{{- include "minio.validateValues" . }}
+
+{{- $requiredPassword := list -}}
+{{- $secretName := include "minio.secretName" . -}}
+{{- if and (not .Values.existingSecret) (not .Values.forceNewKeys) (not .Values.gateway.enabled) -}}
+  {{- $requiredAccessKey := dict "valueKey" "accessKey.password" "secret" $secretName "field" "access-key" -}}
+  {{- $requiredSecretKey := dict "valueKey" "secretKey.password" "secret" $secretName "field" "secret-key" -}}
+  {{- $requiredPassword = append $requiredPassword $requiredAccessKey -}}
+  {{- $requiredPassword = append $requiredPassword $requiredSecretKey -}}
+{{- end -}}
+{{- $requiredMinioPasswordErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPassword "context" $) -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredMinioPasswordErrors) "context" $) -}}

--- a/minio/templates/_helpers.tpl
+++ b/minio/templates/_helpers.tpl
@@ -1,0 +1,283 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the proper MinIO(R) image name
+*/}}
+{{- define "minio.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+
+{{- end -}}
+
+{{/*
+Return the proper MinIO(R) Client image name
+*/}}
+{{- define "minio.clientImage" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.clientImage "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "minio.volumePermissions.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.volumePermissions.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "minio.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.clientImage .Values.volumePermissions.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Get the user to use to access MinIO(R)
+*/}}
+{{- define "minio.secret.userValue" -}}
+{{- if .Values.gateway.enabled }}
+    {{- if eq .Values.gateway.type "azure" }}
+        {{- if .Values.gateway.auth.azure.accessKey }}
+            {{- .Values.gateway.auth.azure.accessKey -}}
+        {{- else -}}
+            {{- randAlphaNum 10 -}}
+        {{- end -}}
+    {{- else if eq .Values.gateway.type "gcs" }}
+        {{- if .Values.gateway.auth.gcs.accessKey }}
+            {{- .Values.gateway.auth.gcs.accessKey -}}
+        {{- else -}}
+            {{- randAlphaNum 10 -}}
+        {{- end -}}
+    {{- else if eq .Values.gateway.type "nas" }}
+        {{- if .Values.gateway.auth.nas.accessKey }}
+            {{- .Values.gateway.auth.nas.accessKey -}}
+        {{- else -}}
+            {{- randAlphaNum 10 -}}
+        {{- end -}}
+    {{- else if eq .Values.gateway.type "s3" }}
+        {{- .Values.gateway.auth.s3.accessKey -}}
+    {{- end -}}
+{{- else }}
+    {{- $accessKey := coalesce .Values.global.minio.accessKey .Values.accessKey.password -}}
+    {{- if $accessKey }}
+        {{- $accessKey -}}
+    {{- else if (not .Values.accessKey.forcePassword) }}
+        {{- randAlphaNum 10 -}}
+    {{- else -}}
+        {{ required "An Access Key is required!" .Values.accessKey.password }}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the password to use to access MinIO(R)
+*/}}
+{{- define "minio.secret.passwordValue" -}}
+{{- if .Values.gateway.enabled }}
+    {{- if eq .Values.gateway.type "azure" }}
+        {{- if .Values.gateway.auth.azure.secretKey }}
+            {{- .Values.gateway.auth.azure.secretKey -}}
+        {{- else -}}
+            {{- randAlphaNum 40 -}}
+        {{- end -}}
+    {{- else if eq .Values.gateway.type "gcs" }}
+        {{- if .Values.gateway.auth.gcs.secretKey }}
+            {{- .Values.gateway.auth.gcs.secretKey -}}
+        {{- else -}}
+            {{- randAlphaNum 40 -}}
+        {{- end -}}
+    {{- else if eq .Values.gateway.type "nas" }}
+        {{- if .Values.gateway.auth.nas.secretKey }}
+            {{- .Values.gateway.auth.nas.secretKey -}}
+        {{- else -}}
+            {{- randAlphaNum 40 -}}
+        {{- end -}}
+    {{- else if eq .Values.gateway.type "s3" }}
+        {{- .Values.gateway.auth.s3.secretKey -}}
+    {{- end -}}
+{{- else }}
+    {{- $secretKey := coalesce .Values.global.minio.secretKey .Values.secretKey.password -}}
+    {{- if $secretKey }}
+        {{- $secretKey -}}
+    {{- else if (not .Values.secretKey.forcePassword) }}
+        {{- randAlphaNum 40 -}}
+    {{- else -}}
+        {{ required "A Secret Key is required!" .Values.secretKey.password }}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the credentials secret.
+*/}}
+{{- define "minio.secretName" -}}
+{{- if .Values.global.minio.existingSecret }}
+    {{- printf "%s" .Values.global.minio.existingSecret -}}
+{{- else if .Values.existingSecret -}}
+    {{- printf "%s" .Values.existingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "minio.createSecret" -}}
+{{- if .Values.global.minio.existingSecret }}
+{{- else if .Values.existingSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a PVC object should be created (only in standalone mode)
+*/}}
+{{- define "minio.createPVC" -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (or (and (eq .Values.mode "standalone") (not .Values.gateway.enabled)) (and .Values.gateway.enabled (eq .Values.gateway.type "nas"))) }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the PVC name (only in standalone mode)
+*/}}
+{{- define "minio.claimName" -}}
+{{- if and .Values.persistence.existingClaim }}
+    {{- printf "%s" (tpl .Values.persistence.existingClaim $) -}}
+{{- else -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the proper service account name depending if an explicit service account name is set
+in the values file. If the name is not set it will default to either common.names.fullname if serviceAccount.create
+is true or default otherwise.
+*/}}
+{{- define "minio.serviceAccountName" -}}
+    {{- if .Values.serviceAccount.create -}}
+        {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+    {{- else -}}
+        {{ default "default" .Values.serviceAccount.name }}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "minio.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "minio.validateValues.mode" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.totalDrives" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.tls" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.gateway.type" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.gateway.azure.credentials" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.gateway.gcs.projectID" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.gateway.nas.persistence" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.gateway.s3.credentials" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - must provide a valid mode ("distributed" or "standalone")
+*/}}
+{{- define "minio.validateValues.mode" -}}
+{{- $allowedValues := list "distributed" "standalone" }}
+{{- if not (has .Values.mode $allowedValues) -}}
+minio: mode
+    Invalid mode selected. Valid values are "distributed" and
+    "standalone". Please set a valid mode (--set mode="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - total number of drives should be multiple of 4
+*/}}
+{{- define "minio.validateValues.totalDrives" -}}
+{{- $replicaCount := int .Values.statefulset.replicaCount }}
+{{- $drivesPerNode := int .Values.statefulset.drivesPerNode }}
+{{- $totalDrives := mul $replicaCount $drivesPerNode }}
+{{- if and (eq .Values.mode "distributed") (or (not (eq (mod $totalDrives 4) 0)) (lt $totalDrives 4)) -}}
+minio: total drives
+    The total number of drives should be multiple of 4 to guarantee erasure coding!
+    Please set a combination of nodes, and drives per node that match this condition.
+    For instance (--set statefulset.replicaCount=2 --set statefulset.drivesPerNode=2)
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - TLS secret must provided if TLS is enabled
+*/}}
+{{- define "minio.validateValues.tls" -}}
+{{- if and .Values.tls.enabled (not .Values.tls.secretName) }}
+minio: tls.secretName
+    The name of an existing secret containing the certificates must be provided
+    if TLS is enabled. Please set its name (--set tls.secretName=X)
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - must provide a valid gateway type ("azure", "gcs", "nas" or "s3")
+*/}}
+{{- define "minio.validateValues.gateway.type" -}}
+{{- $allowedValues := list "azure" "gcs" "nas" "s3" }}
+{{- if and .Values.gateway.enabled (not (has .Values.gateway.type $allowedValues)) -}}
+minio: gateway.type
+    Invalid Gateway type. Valid values are "azure", "gcs", "nas" and "s3".
+    Please set a valid mode (--set gateway.type="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - when using MinIO(R) as an Azure Gateway, the StorageAccount Name/Key are required
+*/}}
+{{- define "minio.validateValues.gateway.azure.credentials" -}}
+{{- if and .Values.gateway.enabled (eq .Values.gateway.type "azure") (or (empty .Values.gateway.auth.azure.storageAccountName) (empty .Values.gateway.auth.azure.storageAccountKey)) }}
+minio: gateway.auth.azure
+    The StorageAccount name and key are required to use MinIO(R) as a Azure Gateway.
+    Please set a valid StorageAccount information (--set gateway.auth.azure.storageAccountName="xxxx",gateway.auth.azure.storageAccountKey="yyyy")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - when using MinIO(R) as a GCS Gateway, the GCP project ID is required
+*/}}
+{{- define "minio.validateValues.gateway.gcs.projectID" -}}
+{{- if and .Values.gateway.enabled (eq .Values.gateway.type "gcs") (empty .Values.gateway.auth.gcs.projectID) }}
+minio: gateway.auth.gcs.projectID
+    A GCP project ID is required to use MinIO(R) as a GCS Gateway.
+    Please set a valid project ID (--set gateway.auth.gcs.projectID="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - when using MinIO(R) as a NAS Gateway, ReadWriteMany volumes are required
+*/}}
+{{- define "minio.validateValues.gateway.nas.persistence" -}}
+{{- $replicaCount := int .Values.gateway.replicaCount }}
+{{- if and .Values.gateway.enabled (eq .Values.gateway.type "nas") (gt $replicaCount 1) (not .Values.persistence.enabled) }}
+minio: persistence.enabled
+    ReadWriteMany volumes are required to use MinIO(R) as a NAS Gateway with N replicas.
+    Please enable persistence (--set persistence.enabled=true)
+{{- else if and .Values.gateway.enabled (eq .Values.gateway.type "nas") (gt $replicaCount 1) (include "minio.createPVC" .) (not (has "ReadWriteMany" .Values.persistence.accessModes)) }}
+minio: persistence.accessModes
+    ReadWriteMany volumes are required to use MinIO(R) as a NAS Gateway with N replicas.
+    Please set a valid mode (--set persistence.accessModes[0]="ReadWriteMany")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of MinIO(R) - when using MinIO(R) as a S3 Gateway, the Access & Secret keys are required
+*/}}
+{{- define "minio.validateValues.gateway.s3.credentials" -}}
+{{- if and .Values.gateway.enabled (eq .Values.gateway.type "s3") (or (empty .Values.gateway.auth.s3.accessKey) (empty .Values.gateway.auth.s3.secretKey)) }}
+minio: gateway.auth.s3
+    The Access & Secret keys are required to use MinIO(R) as a S3 Gateway.
+    Please set valid keys (--set gateway.auth.s3.accessKey="xxxx",gateway.auth.s3.secretKey="yyyy")
+{{- end -}}
+{{- end -}}

--- a/minio/templates/distributed/headless-svc.yaml
+++ b/minio/templates/distributed/headless-svc.yaml
@@ -1,0 +1,23 @@
+{{- if and (eq .Values.mode "distributed") (not .Values.gateway.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-headless" (include "common.names.fullname" .) | trunc 63 }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: minio
+      port: {{ .Values.service.port }}
+      targetPort: minio
+  publishNotReadyAddresses: true
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/minio/templates/distributed/pdb.yaml
+++ b/minio/templates/distributed/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.pdb.create (eq .Values.mode "distributed") (not .Values.gateway.enabled) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/minio/templates/distributed/statefulset.yaml
+++ b/minio/templates/distributed/statefulset.yaml
@@ -1,0 +1,321 @@
+{{- if and (eq .Values.mode "distributed") (not .Values.gateway.enabled) }}
+{{- $fullname := include "common.names.fullname" . }}
+{{- $headlessService := printf "%s-headless" (include "common.names.fullname" .) | trunc 63 }}
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $clusterDomain := .Values.clusterDomain }}
+{{- $replicaCount := int .Values.statefulset.replicaCount }}
+{{- $zoneCount := int .Values.statefulset.zones }}
+{{- $drivesPerNode := int .Values.statefulset.drivesPerNode }}
+{{- $mountPath := .Values.persistence.mountPath }}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $releaseNamespace  }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  serviceName: {{ $headlessService }}
+  replicas: {{ mul $zoneCount $replicaCount }}
+  podManagementPolicy: {{ .Values.statefulset.podManagementPolicy }}
+  updateStrategy:
+    type: {{ .Values.statefulset.updateStrategy }}
+    {{- if (eq "Recreate" .Values.statefulset.updateStrategy) }}
+    rollingUpdate: null
+    {{- end }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.podAnnotations (include "minio.createSecret" .) }}
+      annotations:
+        {{- if (include "minio.createSecret" .) }}
+        checksum/credentials-secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "minio.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      serviceAccountName: {{ template "minio.serviceAccountName" . }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- if or .Values.initContainers (and .Values.volumePermissions.enabled .Values.persistence.enabled) }}
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ template "minio.volumePermissions.image" . }}
+          imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              {{- if and .Values.persistence.enabled (gt $drivesPerNode 1) }}
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {{ range $diskId := until $drivesPerNode }}{{  $mountPath }}-{{ $diskId }} {{ end }}
+              {{- else }}
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {{ $mountPath }}
+              {{- end }}
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if and .Values.persistence.enabled (gt $drivesPerNode 1) }}
+            {{- range $diskId := until $drivesPerNode }}
+            - name: data-{{ $diskId }}
+              mountPath: {{  $mountPath }}-{{ $diskId }}
+            {{- end }}
+            {{- else }}
+            - name: data
+              mountPath: {{  $mountPath }}
+            {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: minio
+          image: {{ include "minio.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          {{- end }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: MINIO_DISTRIBUTED_MODE_ENABLED
+              value: "yes"
+            - name: MINIO_DISTRIBUTED_NODES
+              {{- $clusters := list }}
+              {{- range $i := until $zoneCount }}
+                  {{- $factor := mul $i $replicaCount }}
+                  {{- $endIndex := sub (add $factor $replicaCount) 1 }}
+                  {{- $beginIndex := mul $i $replicaCount }}
+                  {{- $bucket := ternary (printf "%s-{0...%d}" $mountPath (sub $drivesPerNode 1)) $mountPath (gt $drivesPerNode 1) }}
+                  {{- $clusters = append $clusters (printf "%s-{%d...%d}.%s.%s.svc.%s%s" $fullname $beginIndex $endIndex $headlessService $releaseNamespace $clusterDomain $bucket) }}
+              {{- end }}
+              value: {{ join "," $clusters | quote }}
+            - name: MINIO_SCHEME
+              value: {{ ternary "https" "http" .Values.tls.enabled | quote }}
+            - name: MINIO_FORCE_NEW_KEYS
+              value: {{ ternary "yes" "no" .Values.forceNewKeys | quote }}
+            {{- if .Values.useCredentialsFile }}
+            - name: MINIO_ACCESS_KEY_FILE
+              value: "/opt/bitnami/minio/secrets/access-key"
+            {{- else }}
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: access-key
+            {{- end }}
+            {{- if .Values.useCredentialsFile }}
+            - name: MINIO_SECRET_KEY_FILE
+              value: "/opt/bitnami/minio/secrets/secret-key"
+            {{- else }}
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: secret-key
+            {{- end }}
+            - name: MINIO_SKIP_CLIENT
+              value: {{ ternary "yes" "no" (empty .Values.defaultBuckets) | quote }}
+            {{- if .Values.defaultBuckets }}
+            - name: MINIO_DEFAULT_BUCKETS
+              value: {{ .Values.defaultBuckets }}
+            {{- end }}
+            - name: MINIO_BROWSER
+              value: {{ ternary "off" "on" .Values.disableWebUI | quote }}
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: {{ .Values.metrics.prometheusAuthType | quote }}
+            {{- if .Values.tls.mountPath }}
+            - name: MINIO_CERTSDIR
+              value: {{ .Values.tls.mountPath | quote }}
+            {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          ports:
+            - name: minio
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: minio
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled | quote }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: minio
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: minio
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.useCredentialsFile }}
+            - name: minio-credentials
+              mountPath: /opt/bitnami/minio/secrets/
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: minio-certs
+              mountPath: {{ default "/certs" .Values.tls.mountPath }}
+            {{- end }}
+            {{- if and .Values.persistence.enabled (gt $drivesPerNode 1) }}
+            {{- range $diskId := until $drivesPerNode }}
+            - name: data-{{ $diskId }}
+              mountPath: {{  $mountPath }}-{{ $diskId }}
+            {{- end }}
+            {{- else }}
+            - name: data
+              mountPath: {{  $mountPath }}
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if .Values.useCredentialsFile }}
+        - name: minio-credentials
+          secret:
+            secretName: {{ include "minio.secretName" . }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: minio-certs
+          secret:
+            secretName: {{ .Values.tls.secretName }}
+            items:
+            - key: tls.crt 
+              path: public.crt
+            - key: tls.key
+              path: private.key
+            - key: ca.crt
+              path: CAs/public.crt
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+  {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else }}
+  volumeClaimTemplates:
+  {{- if gt $drivesPerNode 1 }}
+    {{- range $diskId := until $drivesPerNode }}
+    - metadata:
+        name: data-{{ $diskId }}
+        labels: {{- include "common.labels.matchLabels" $ | nindent 10 }}
+        {{- if $.Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range $.Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $.Values.persistence.size | quote }}
+        {{- include "common.storage.class" (dict "persistence" $.Values.persistence "global" $.Values.global) | nindent 8 }}
+    {{- end }}
+  {{- else }}
+    - metadata:
+        name: data
+        labels: {{- include "common.labels.matchLabels" . | nindent 10 }}
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/minio/templates/extra-list.yaml
+++ b/minio/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/minio/templates/gateway/deployment.yaml
+++ b/minio/templates/gateway/deployment.yaml
@@ -1,0 +1,178 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.gateway.replicaCount }}
+  {{- if .Values.deployment.updateStrategy }}
+  strategy: {{- toYaml .Values.deployment.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.podAnnotations (include "minio.createSecret" .) }}
+      annotations:
+        {{- if (include "minio.createSecret" .) }}
+        checksum/credentials-secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "minio.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      serviceAccountName: {{ template "minio.serviceAccountName" . }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: minio
+          image: {{ include "minio.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          {{- end }}
+          command:
+            {{- if .Values.command }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+            {{- else }}
+            - minio
+            {{- end }}
+          args:
+            {{- if .Values.args }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+            {{- else }}
+            - --certs-dir
+            - /opt/bitnami/minio/certs
+            - gateway
+            - {{ .Values.gateway.type }}
+            {{- if eq .Values.gateway.type "gcs" }}
+            - {{ .Values.gateway.auth.gcs.projectID }}
+            {{- else if eq .Values.gateway.type "nas" }}
+            - {{ .Values.persistence.mountPath }}
+            {{- else if eq .Values.gateway.type "s3" }}
+            - {{ .Values.gateway.auth.s3.serviceEndpoint }}
+            {{- end }}
+            {{- end }}
+          env:
+            {{- if eq .Values.gateway.type "azure" }}
+            - name: AZURE_STORAGE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: azure-storage-account-name
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: azure-storage-account-key
+            {{- else if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/opt/bitnami/minio/secrets/key.json"
+            {{- end }}
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: access-key
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: secret-key
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: {{ .Values.metrics.prometheusAuthType | quote }}
+            {{- if .Values.extraEnv }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          ports:
+            - name: minio
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON }}
+            - name: minio-credentials
+              mountPath: /opt/bitnami/minio/secrets/
+              readOnly: true
+            {{- end }}
+            {{- if eq .Values.gateway.type "nas" }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON }}
+        - name: minio-credentials
+          secret:
+            secretName: {{ include "minio.secretName" . }}
+        {{- end }}
+        {{- if eq .Values.gateway.type "nas" }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "minio.claimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/minio/templates/ingress.yaml
+++ b/minio/templates/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.ingress.enabled (not .Values.disableWebUI ) -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "minio" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "minio" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/minio/templates/networkpolicy.yaml
+++ b/minio/templates/networkpolicy.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  ingress:
+    # Allow inbound connections
+    - ports:
+        - port: {{ .Values.containerPort }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ include "common.names.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
+      {{- end }}
+{{- end }}

--- a/minio/templates/pvc.yaml
+++ b/minio/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if (include "minio.createPVC" .) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.persistence.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
+{{- end }}

--- a/minio/templates/secrets.yaml
+++ b/minio/templates/secrets.yaml
@@ -1,0 +1,24 @@
+{{- if (include "minio.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  access-key: {{ include "minio.secret.userValue" . | b64enc | quote }}
+  secret-key: {{ include "minio.secret.passwordValue" . | b64enc | quote }}
+  {{- if eq .Values.gateway.type "azure" }}
+  azure-storage-account-name: {{ .Values.gateway.auth.azure.storageAccountName | toString | b64enc | quote }}
+  azure-storage-account-key: {{ .Values.gateway.auth.azure.storageAccountKey | toString | b64enc | quote }}
+  {{- else if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON | quote }}
+  key.json: {{ .Values.gateway.auth.gcs.keyJSON | toString | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/minio/templates/service.yaml
+++ b/minio/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{ if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: minio
+      port: {{ .Values.service.port }}
+      targetPort: minio
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/minio/templates/serviceaccount.yaml
+++ b/minio/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "minio.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+secrets:
+  - name: {{ include "common.names.fullname" . }}
+{{- end }}

--- a/minio/templates/servicemonitor.yaml
+++ b/minio/templates/servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: minio
+      path: {{ .Values.metrics.serviceMonitor.path }}
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabellings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.relabellings | nindent 6 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/minio/templates/standalone/deployment.yaml
+++ b/minio/templates/standalone/deployment.yaml
@@ -1,0 +1,219 @@
+{{- if and (eq .Values.mode "standalone") (not .Values.gateway.enabled) }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.deployment.updateStrategy }}
+  strategy: {{- toYaml .Values.deployment.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.podAnnotations (include "minio.createSecret" .) }}
+      annotations:
+        {{- if (include "minio.createSecret" .) }}
+        checksum/credentials-secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "minio.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      serviceAccountName: {{ template "minio.serviceAccountName" . }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- if or .Values.initContainers (and .Values.volumePermissions.enabled .Values.persistence.enabled) }}
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ template "minio.volumePermissions.image" . }}
+          imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: minio
+          image: {{ include "minio.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          {{- end }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: MINIO_FORCE_NEW_KEYS
+              value: {{ ternary "yes" "no" .Values.forceNewKeys | quote }}
+            {{- if .Values.useCredentialsFile }}
+            - name: MINIO_ACCESS_KEY_FILE
+              value: "/opt/bitnami/minio/secrets/access-key"
+            {{- else }}
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: access-key
+            {{- end }}
+            {{- if .Values.useCredentialsFile }}
+            - name: MINIO_SECRET_KEY_FILE
+              value: "/opt/bitnami/minio/secrets/secret-key"
+            {{- else }}
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: secret-key
+            {{- end }}
+            {{- if .Values.defaultBuckets }}
+            - name: MINIO_DEFAULT_BUCKETS
+              value: {{ .Values.defaultBuckets }}
+            {{- end }}
+            - name: MINIO_BROWSER
+              value: {{ ternary "off" "on" .Values.disableWebUI | quote }}
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: {{ .Values.metrics.prometheusAuthType | quote }}
+            {{- if .Values.extraEnv }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          ports:
+            - name: minio
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: minio
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: minio
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: minio
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.useCredentialsFile }}
+            - name: minio-credentials
+              mountPath: /opt/bitnami/minio/secrets/
+            {{- end }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if .Values.useCredentialsFile }}
+        - name: minio-credentials
+          secret:
+            secretName: {{ include "minio.secretName" . }}
+        {{- end }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "minio.claimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/minio/templates/tls-secrets.yaml
+++ b/minio/templates/tls-secrets.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- $ca := genCA "minio-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/minio/values.yaml
+++ b/minio/values.yaml
@@ -1,0 +1,685 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+##
+global:
+  ## Global imageRegistry
+  ##
+  # imageRegistry: myRegistryName
+  ## Global imagePullSecrets
+  ##
+  imagePullSecrets: []
+  ## Global storageClass
+  ##
+  # storageClass: myStorageClass
+  ## Global MinIO(R) credentials
+  ## e.g:
+  ## minio:
+  ##   existingSecret: ""
+  ##   accessKey: ""
+  ##   secretKey: ""
+  ##
+  minio: {}
+
+## Bitnami MinIO(R) image version
+## ref: https://hub.docker.com/r/bitnami/minio/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/minio
+  tag: 2021.6.14-debian-10-r0
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
+
+## Bitnami MinIO(R) Client image version
+## ref: https://hub.docker.com/r/bitnami/minio-client/tags/
+##
+clientImage:
+  registry: docker.io
+  repository: bitnami/minio-client
+  tag: 2021.6.13-debian-10-r0
+
+## String to partially override common.names.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override common.names.fullname template
+##
+# fullnameOverride:
+
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
+## Cluster domain
+##
+clusterDomain: cluster.local
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
+## MinIO(R) server mode. Allowed values: standalone or distributed.
+## ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+mode: standalone
+
+## MinIO(R) credentials
+##
+accessKey:
+  ## MinIO(R) Access Key
+  ## ref: https://github.com/bitnami/bitnami-docker-minio/#setting-up-minio-in-distributed-mode
+  ##
+  password:
+  ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
+  ## If it is not force, a random password will be generated.
+  ##
+  forcePassword: false
+secretKey:
+  ## MinIO(R) Secret Key
+  ## ref: https://github.com/bitnami/bitnami-docker-minio/#setting-up-minio-in-distributed-mode
+  ##
+  password:
+  ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
+  ## If it is not force, a random password will be generated.
+  ##
+  forcePassword: false
+
+## Use existing secret (ignores accessKey, and secretKey passwords)
+##
+# existingSecret:
+
+## Mount MinIO(R) secret as a file instead of passing environment variable
+##
+useCredentialsFile: false
+
+## Force reconfiguring new keys whenever the credentials change
+##
+forceNewKeys: false
+
+## Comma, semi-colon or space separated list of buckets to create at initialization
+##
+# defaultBuckets: "my-bucket, my-second-bucket"
+
+## Disable MinIO(R) Web UI
+## ref: https://github.com/minio/minio/tree/master/docs/config/#browser
+##
+disableWebUI: false
+
+## Enable tls in front of MinIO(R) containers.
+##
+tls:
+  ## If true, mount an existing secret to the container
+  ##
+  enabled: false
+  ## Name of an existing secret holding the certificate information
+  ##
+  secretName: ""
+  ## The mounted path where the secret will be located
+  ##  Custom mount path where the certificates will be located, if empty will default to /certs
+  mountPath: ""
+
+## An array to add extra env vars
+## e.g:
+## extraEnv:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnv: {}
+
+## ConfigMap with extra environment variables
+##
+extraEnvVarsCM: ""
+
+## Secret with extra environment variables
+##
+extraEnvVarsSecret: ""
+
+## Command and args for running the MinIO(R) container (set to default if not set). Use array form
+##
+command: []
+args: []
+
+## Scheduler name
+## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName: stork
+
+## MinIO(R) deployment parameters
+## Only when 'mode' is 'standalone' or 'gateway.enabled' is 'true'
+##
+deployment:
+  ## Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to make sure the pods is destroyed first.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  ## e.g:
+  ## updateStrategy:
+  ##  type: RollingUpdate
+  ##  rollingUpdate:
+  ##    maxSurge: 25%
+  ##    maxUnavailable: 25%
+  ##
+  updateStrategy:
+    type: Recreate
+
+## MinIO(R) statefulset parameters
+## Only when mode is 'distributed'
+##
+statefulset:
+  ## Update strategy, can be set to RollingUpdate or OnDelete by default.
+  ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
+  ##
+  updateStrategy: RollingUpdate
+
+  ## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
+  ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+  ##
+  podManagementPolicy: Parallel
+
+  ## Number of replicas, it must even and greater than 4
+  ##
+  replicaCount: 4
+
+  ## Number of expanded MinIO(R) clusters
+  ##
+  zones: 1
+
+  ## Number of drives (PVC) attached to every node
+  ##
+  drivesPerNode: 1
+
+## MinIO(R) pod host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+
+## MinIO(R) container ports to open
+##
+containerPort: 9000
+
+## Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+  runAsNonRoot: true
+
+## Pod labels
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  ##
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## MinIO(R) containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 250m
+  #   memory: 256Mi
+  requests: {}
+  #   cpu: 250m
+  #   memory: 256Mi
+
+## Configure extra options for liveness, readiness and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 5
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 60
+
+## Custom Liveness, Readiness, and Startup probes for MinIO(R)
+##
+customLivenessProbe: {}
+customReadinessProbe: {}
+customStartupProbe: {}
+
+## Extra volumes to add to the MinIO(R) statefulset
+##
+extraVolumes: []
+
+## Extra volume mounts to add to MinIO(R) containers
+##
+extraVolumeMounts: []
+
+## Add init containers to the MinIO(R) pods.
+## e.g:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+
+## Add sidecars to the MinIO(R) pods.
+## e.g:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
+## MinIO(R) Service properties
+##
+service:
+  ## MinIO(R) Service type
+  ##
+  type: ClusterIP
+  ## MinIO(R) Service port
+  ##
+  port: 9000
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## loadBalancerIP for the MinIO(R) Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  # loadBalancerIP:
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+
+## Configure the ingress resource that allows you to access the
+## MinIO(R) installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  apiVersion:
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: minio.local
+
+  ## The Path to MinIO(R). You may need to set this to '/*' in order to use this
+  ## with ALB ingress controllers.
+  ##
+  path: /
+
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
+  ## The service port to be used by this ingress.
+  ## Default is http. Alternative is https.
+  ##
+  servicePort: minio
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ##
+  tls: false
+
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## e.g:
+  ## extraHosts:
+  ##   - name: minio.local
+  ##     path: /
+  ##
+  extraHosts: []
+
+  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - minio.local
+  ##   secretName: minio.local-tls
+  ##
+  extraTls: []
+
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate are expected in PEM format
+  ## name should line up with a secretName set further up
+  ##
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## Example
+  ## secrets:
+  ##   - name: minio.local-tls
+  ##     key: ""
+  ##     certificate: ""
+  ##
+  secrets: []
+
+## NetworkPolicy parameters
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port MinIO(R) is listening
+  ## on. When true, MinIO(R) will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  ## If true, use a Persistent Volume Claim, If false, use emptyDir
+  ##
+  enabled: true
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ## Data volume mount path
+  ##
+  mountPath: /data
+  ## Persistent Volume Access Mode
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## Persistent Volume size
+  ##
+  size: 8Gi
+  ## Persistent Volume Claim annotations
+  ##
+  annotations: {}
+  ## Enable persistence using an existing PVC (only in standalone mode)
+  ##
+  # existingClaim:
+
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
+##
+volumePermissions:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r106
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## e.g:
+    ## limits:
+    ##   cpu: 500m
+    ##   memory: 1Gi
+    ##
+    limits: {}
+    requests: {}
+
+## Specifies whether a ServiceAccount should be created
+##
+serviceAccount:
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+
+## MinIO(R) Pod Disruption Budget configuration (only in distributed mode)
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+##
+pdb:
+  create: false
+  ## Min number of pods that must still be available after the eviction
+  ##
+  minAvailable: 1
+  ## Max number of pods that can be unavailable after the eviction
+  ##
+  # maxUnavailable: 1
+
+## Metrics configuration
+##
+metrics:
+  ## MinIO(R) supports two authentication modes for Prometheus either jwt or public, by default MinIO(R) runs in jwt mode.
+  ## To allow public access without authentication for prometheus metrics set environment as follows.
+  ##
+  prometheusAuthType: public
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
+    enabled: false
+    ## Specify the namespace in which the serviceMonitor resource will be created
+    ##
+    # namespace: ""
+    ## HTTP path to scrape for metrics
+    ##
+    path: /minio/v2/metrics/cluster
+    ## Specify the interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## Specify the timeout after which the scrape is ended
+    ##
+    # scrapeTimeout: 30s
+    ## Specify Metric Relabellings to add to the scrape endpoint
+    ##
+    # relabellings:
+    ## Specify honorLabels parameter to add the scrape endpoint
+    ##
+    honorLabels: false
+    ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
+    ##
+    # release: ""
+    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    additionalLabels: {}
+
+## MinIO(R) Gateway configuration
+##
+gateway:
+  ## Use MinIO(R) as Gateway for other storage systems
+  ##
+  enabled: false
+  ## Gateway type
+  ## Current supported types are: azure, gcs, nas, and s3
+  ## ref: https://docs.minio.io/docs/minio-gateway-for-azure
+  ## ref: https://docs.minio.io/docs/minio-gateway-for-gcs
+  ## ref: https://docs.minio.io/docs/minio-gateway-for-nas
+  ## ref: https://docs.minio.io/docs/minio-gateway-for-s3
+  ##
+  type: s3
+  ## Number of Gateway replicas
+  ##
+  replicaCount: 4
+  ## Gateway authentication configuration
+  ##
+  auth:
+    ## Authentication configuration for Azure
+    ## Ignored unless type=azure
+    ##
+    azure:
+      accessKey: ""
+      secretKey: ""
+      storageAccountName: ""
+      storageAccountKey: ""
+    ## Authentication configuration for GCS
+    ## Ignored unless type=gcs
+    ##
+    gcs:
+      accessKey: ""
+      secretKey: ""
+      keyJSON: ""
+      projectID: ""
+    ## Authentication configuration for NAS
+    ## Ignored unless type=nas
+    ##
+    nas:
+      accessKey: ""
+      secretKey: ""
+    ## Authentication configuration for S3
+    ## Ignored unless type=s3
+    ##
+    s3:
+      accessKey: ""
+      secretKey: ""
+      serviceEndpoint: https://s3.amazonaws.com

--- a/thanos/.helmignore
+++ b/thanos/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/thanos/Chart.lock
+++ b/thanos/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.3.3
+- name: minio
+  repository: https://charts.bitnami.com/bitnami
+  version: 6.0.0
+digest: sha256:3611cac4a810deb20849025c526cbcdb5487d7a1ac4129be79f8cafc7b21ce28
+generated: "2021-01-15T09:38:07.021289389Z"

--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -1,0 +1,31 @@
+annotations:
+  category: Analytics
+apiVersion: v2
+appVersion: 0.17.2
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+  - condition: minio.enabled
+    name: minio
+    repository: https://openinfradev.github.io/helm-repo
+    version: 6.x.x
+description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/thanos
+icon: https://bitnami.com/assets/stacks/thanos/img/thanos-stack-220x234.png
+keywords:
+  - analytics
+  - monitoring
+  - prometheus
+  - thanos
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: thanos
+sources:
+  - https://github.com/bitnami/bitnami-docker-thanos
+  - https://thanos.io
+version: 3.4.0

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -1,0 +1,870 @@
+# Thanos
+
+[Thanos](https://thanos.io/) is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
+
+## TL;DR
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install my-release bitnami/thanos
+```
+
+## Introduction
+
+This chart bootstraps a [Thanos](https://github.com/bitnami/bitnami-docker-thanos) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3.1.0
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install my-release bitnami/thanos
+```
+
+These commands deploy Thanos on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` chart:
+
+```bash
+helm uninstall my-release
+```
+
+## Architecture
+
+This charts allows you install several Thanos components, so you deploy an architecture as the one below:
+
+```
+                       ┌──────────────┐                  ┌──────────────┐      ┌──────────────┐
+                       │ Thanos       │───────────┬────▶ │ Thanos Store │      │ Thanos       │
+                       │ Query        │           │      │ Gateway      │      │ Compactor    │
+                       └──────────────┘           │      └──────────────┘      └──────────────┘
+                   push                           │             │                     │
+┌──────────────┐   alerts   ┌──────────────┐      │             │ storages            │ Downsample &
+│ Alertmanager │ ◀──────────│ Thanos       │ ◀────┤             │ query metrics       │ compact blocks
+│ (*)          │            │ Ruler        │      │             │                     │
+└──────────────┘            └──────────────┘      │             ▼                     │
+      ▲                            │              │      ┌───────────────┐            │
+      │ push alerts                └──────────────│────▶ │ MinIO(TM) (*) │ ◀──────────┘
+      │                                           │      │               │
+┌ ── ── ── ── ── ── ── ── ── ──┐                  │      └───────────────┘
+│┌────────────┐  ┌────────────┐│                  │             ▲
+││ Prometheus │─▶│ Thanos     ││ ◀────────────────┘             │
+││ (*)        │◀─│ Sidecar (*)││    query                       │ inspect
+│└────────────┘  └────────────┘│    metrics                     │ blocks
+└ ── ── ── ── ── ── ── ── ── ──┘                                │
+                                                         ┌──────────────┐
+                                                         │ Thanos       │
+                                                         │ Bucket Web   │
+                                                         └──────────────┘
+```
+
+> Note: Components marked with (*) are provided by subchart(s) (such as the [Bitnami MinIO<sup>TM</sup> chart](https://github.com/bitnami/charts/tree/master/bitnami/minio)) or external charts (such as the [Bitnami kube-prometheus chart](https://github.com/bitnami/charts/tree/master/bitnami/kube-prometheus)).
+
+Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate-thanos-with-prometheus-and-alertmanager) for detailed instructions to deploy this architecture.
+
+## Parameters
+
+The following tables lists the configurable parameters of the Thanos chart and their default values per section/component:
+
+### Global parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                               | Global Docker image registry                                                                           | `nil`                                                   |
+| `global.imagePullSecrets`                            | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                                | Global storage class for dynamic provisioning                                                          | `nil`                                                   |
+
+### Common parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                                     | Thanos image registry                                                                                  | `docker.io`                                             |
+| `image.repository`                                   | Thanos image name                                                                                      | `bitnami/thanos`                                        |
+| `image.tag`                                          | Thanos image tag                                                                                       | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                                   | Thanos image pull policy                                                                               | `IfNotPresent`                                          |
+| `image.pullSecrets`                                  | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                                       | String to partially override common.names.fullname                                                     | `nil`                                                   |
+| `fullnameOverride`                                   | String to fully override common.names.fullname                                                         | `nil`                                                   |
+| `clusterDomain`                                      | Default Kubernetes cluster domain                                                                      | `cluster.local`                                         |
+| `objstoreConfig`                                     | [Objstore configuration](https://thanos.io/storage.md/#configuration)                                  | `nil`                                                   |
+| `indexCacheConfig`                                   | [Index cache configuration](https://thanos.io/components/store.md/#memcached-index-cache)              | `nil`                                                   |
+| `bucketCacheConfig`                                  | [Bucket cache configuration](https://thanos.io/components/store.md/#caching-bucket)                    | `nil`                                                   |
+| `existingObjstoreSecret`                             | Name of existing secret with Objstore configuration                                                    | `nil`                                                   |
+| `existingObjstoreSecretItems`                        | List of Secret Keys and Paths                                                                          | `[]`                                                    |
+| `existingServiceAccount`                             | Name for the existing service account to be shared between the components                              | `nil`                                                   |
+| `kubeVersion`                                        | Force target Kubernetes version (using Helm capabilities if not set)                                   | `nil`                                                   |
+
+### Thanos Query parameters
+
+| Parameter                                     | Description                                                                                                  | Default                                                 |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `query.enabled`                               | Enable/disable Thanos Query component                                                                        | `true`                                                  |
+| `query.logLevel`                              | Thanos Query log level                                                                                       | `info`                                                  |
+| `query.replicaLabel`                          | Replica indicator(s) along which data is deduplicated                                                        | `[replica]`                                             |
+| `query.dnsDiscovery.enabled`                  | Enable store APIs discovery via DNS                                                                          | `true`                                                  |
+| `query.dnsDiscovery.sidecarsService`          | Sidecars service name to discover them using DNS discovery                                                   | `nil` (evaluated as a template)                         |
+| `query.dnsDiscovery.sidecarsNamespace`        | Sidecars namespace to discover them using DNS discovery                                                      | `nil` (evaluated as a template)                         |
+| `query.stores`                                | Store APIs to connect with Thanos Query                                                                      | `[]`                                                    |
+| `query.sdConfig`                              | Service Discovery configuration                                                                              | `nil`                                                   |
+| `query.existingSDConfigmap`                   | Name of existing ConfigMap with Ruler configuration                                                          | `nil`                                                   |
+| `query.extraFlags`                            | Extra Flags to passed to Thanos Query                                                                        | `[]`                                                    |
+| `query.replicaCount`                          | Number of Thanos Query replicas to deploy                                                                    | `1`                                                     |
+| `query.strategyType`                          | Deployment Strategy Type                                                                                     | `RollingUpdate`                                         |
+| `query.podAntiAffinityPreset`                 | Thanos Query pod anti-affinity preset. Ignored if `query.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
+| `query.nodeAffinityPreset.type`               | Thanos Query node affinity preset type. Ignored if `query.affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
+| `query.nodeAffinityPreset.key`                | Thanos Query node label key to match Ignored if `query.affinity` is set.                                     | `""`                                                    |
+| `query.nodeAffinityPreset.values`             | Thanos Query node label values to match. Ignored if `query.affinity` is set.                                 | `[]`                                                    |
+| `query.affinity`                              | Thanos Query affinity for pod assignment                                                                     | `{}` (evaluated as a template)                          |
+| `query.nodeSelector`                          | Thanos Query node labels for pod assignment                                                                  | `{}` (evaluated as a template)                          |
+| `query.tolerations`                           | Thanos Query tolerations for pod assignment                                                                  | `[]` (evaluated as a template)                          |
+| `query.priorityClassName`                     | Controller priorityClassName                                                                                 | `nil`                                                   |
+| `query.securityContext.enabled`               | Enable security context for Thanos Query pods                                                                | `true`                                                  |
+| `query.securityContext.fsGroup`               | Group ID for the Thanos Query filesystem                                                                     | `1001`                                                  |
+| `query.securityContext.runAsUser`             | User ID for the Thanos Query container                                                                       | `1001`                                                  |
+| `query.resources.limits`                      | The resources limits for the Thanos Query container                                                          | `{}`                                                    |
+| `query.resources.requests`                    | The requested resources for the Thanos Query container                                                       | `{}`                                                    |
+| `query.podAnnotations`                        | Annotations for Thanos Query pods                                                                            | `{}`                                                    |
+| `query.livenessProbe`                         | Liveness probe configuration for Thanos Query                                                                | `Check values.yaml file`                                |
+| `query.readinessProbe`                        | Readiness probe configuration for Thanos Query                                                               | `Check values.yaml file`                                |
+| `query.grpcTLS.server.secure`                 | Enable TLS for GRPC server                                                                                   | `false`                                                 |
+| `query.grpcTLS.server.cert`                   | TLS Certificate for gRPC server                                                                              | `nil`                                                   |
+| `query.grpcTLS.server.key`                    | TLS Key for gRPC server                                                                                      | `nil`                                                   |
+| `query.grpcTLS.server.ca`                     | TLS client CA for gRPC server used for client verification purposes on the server                            | `nil`                                                   |
+| `query.grpcTLS.client.secure`                 | Use TLS when talking to the gRPC server                                                                      | `false`                                                 |
+| `query.grpcTLS.client.cert`                   | TLS Certificates to use to identify this client to the server                                                | `nil`                                                   |
+| `query.grpcTLS.client.key`                    | TLS Key for the client's certificate                                                                         | `nil`                                                   |
+| `query.grpcTLS.client.ca`                     | TLS CA Certificates to use to verify gRPC servers                                                            | `nil`                                                   |
+| `query.grpcTLS.client.servername`             | Server name to verify the hostname on the returned gRPC certificates.                                        | `nil`                                                   |
+| `query.service.type`                          | Kubernetes service type                                                                                      | `ClusterIP`                                             |
+| `query.service.clusterIP`                     | Thanos Query service clusterIP IP                                                                            | `None`                                                  |
+| `query.service.http.port`                     | Service HTTP port                                                                                            | `9090`                                                  |
+| `query.service.http.nodePort`                 | Service HTTP node port                                                                                       | `nil`                                                   |
+| `query.service.grpc.port`                     | Service GRPC port                                                                                            | `10901`                                                 |
+| `query.service.grpc.nodePort`                 | Service GRPC node port                                                                                       | `nil`                                                   |
+| `query.service.loadBalancerIP`                | loadBalancerIP if service type is `LoadBalancer`                                                             | `nil`                                                   |
+| `query.service.loadBalancerSourceRanges`      | Address that are allowed when service is LoadBalancer                                                        | `[]`                                                    |
+| `query.service.annotations`                   | Annotations for Thanos Query service                                                                         | `{}`                                                    |
+| `query.service.labelSelectorsOverride`        | Selector for Thanos query service                                                                            | `{}`                                                    |
+| `query.serviceAccount.annotations`            | Annotations for Thanos Query Service Account                                                                 | `{}`                                                    |
+| `query.rbac.create`                           | Create RBAC                                                                                                  | `false`                                                 |
+| `query.pspEnabled`                            | Create PodSecurityPolicy                                                                                     | `false`                                                 |
+| `query.autoscaling.enabled`                   | Enable autoscaling for Thanos Query                                                                          | `false`                                                 |
+| `query.autoscaling.minReplicas`               | Minimum number of Thanos Query replicas                                                                      | `nil`                                                   |
+| `query.autoscaling.maxReplicas`               | Maximum number of Thanos Query replicas                                                                      | `nil`                                                   |
+| `query.autoscaling.targetCPU`                 | Target CPU utilization percentage                                                                            | `nil`                                                   |
+| `query.autoscaling.targetMemory`              | Target Memory utilization percentage                                                                         | `nil`                                                   |
+| `query.pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                                              | `false`                                                 |
+| `query.pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                                               | `1`                                                     |
+| `query.pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                                               | `nil`                                                   |
+| `query.ingress.enabled`                       | Enable ingress controller resource                                                                           | `false`                                                 |
+| `query.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                | ``                                                      |
+| `query.ingress.path`                          | Ingress path                                                                                                 | `/`                                                     |
+| `query.ingress.pathType`                      | Ingress path type                                                                                            | `ImplementationSpecific`                                |
+| `query.ingress.certManager`                   | Add annotations for cert-manager                                                                             | `false`                                                 |
+| `query.ingress.hostname`                      | Default host for the ingress resource                                                                        | `thanos.local`                                          |
+| `query.ingress.annotations`                   | Ingress annotations                                                                                          | `[]`                                                    |
+| `query.ingress.tls`                           | Create ingress TLS section                                                                                   | `false`                                                 |
+| `query.ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                                           | `nil`                                                   |
+| `query.ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                                           | `nil`                                                   |
+| `query.ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                                     | `nil`                                                   |
+| `query.ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                                     | `nil`                                                   |
+| `query.ingress.secrets[0].name`               | TLS Secret Name                                                                                              | `nil`                                                   |
+| `query.ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                                       | `nil`                                                   |
+| `query.ingress.secrets[0].key`                | TLS Secret Key                                                                                               | `nil`                                                   |
+| `query.ingress.grpc.enabled`                  | Enable ingress controller resource (GRPC)                                                                    | `false`                                                 |
+| `query.ingress.grpc.certManager`              | Add annotations for cert-manager (GRPC)                                                                      | `false`                                                 |
+| `query.ingress.grpc.hostname`                 | Default host for the ingress resource (GRPC)                                                                 | `thanos.local`                                          |
+| `query.ingress.grpc.annotations`              | Ingress annotations (GRPC)                                                                                   | `[]`                                                    |
+| `query.ingress.grpc.extraHosts[0].name`       | Additional hostnames to be covered (GRPC)                                                                    | `nil`                                                   |
+| `query.ingress.grpc.extraHosts[0].path`       | Additional hostnames to be covered (GRPC)                                                                    | `nil`                                                   |
+| `query.ingress.grpc.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered (GRPC)                                              | `nil`                                                   |
+| `query.ingress.grpc.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered (GRPC)                                              | `nil`                                                   |
+| `query.ingress.grpc.secrets[0].name`          | TLS Secret Name (GRPC)                                                                                       | `nil`                                                   |
+| `query.ingress.grpc.secrets[0].certificate`   | TLS Secret Certificate (GRPC)                                                                                | `nil`                                                   |
+| `query.ingress.grpc.secrets[0].key`           | TLS Secret Key (GRPC)                                                                                        | `nil`                                                   |
+
+### Thanos Query Frontend parameters
+
+| Parameter                                       | Description                                                                                            | Default                                                 |
+|-------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `queryFrontend.enabled`                         | Enable/disable Thanos Query Frontend component                                                         | `true`                                                  |
+| `queryFrontend.logLevel`                        | Thanos Query Frontend log level                                                                        | `info`                                                  |
+| `queryFrontend.extraFlags`                      | Extra Flags to passed to Thanos Query Frontend                                                         | `[]`                                                    |
+| `queryFrontend.config`                          | Thanos Query Frontend cache configuration                                                              | `nil`                                                   |
+| `queryFrontend.existingConfigmap`               | Name of existing ConfigMap with Thanos Query Frontend cache configuration                              | `nil`                                                   |
+| `queryFrontend.replicaCount`                    | Number of Thanos Query Frontend replicas to deploy                                                     | `1`                                                     |
+| `queryFrontend.strategyType`                    | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
+| `queryFrontend.podAntiAffinityPreset`           | Thanos Query Frontend pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                           |
+| `queryFrontend.nodeAffinityPreset.type`         | Thanos Query Frontend node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard` | `""`                             |
+| `queryFrontend.nodeAffinityPreset.key`          | Thanos Query Frontend node label key to match Ignored if `queryFrontend.affinity` is set.                                     | `""`                             |
+| `queryFrontend.nodeAffinityPreset.values`       | Thanos Query Frontend node label values to match. Ignored if `queryFrontend.affinity` is set.                                 | `[]`                             |
+| `queryFrontend.affinity`                        | Thanos Query Frontend affinity for pod assignment                                                                             | `{}` (evaluated as a template)   |
+| `queryFrontend.nodeSelector`                    | Thanos Query Frontend node labels for pod assignment                                                                          | `{}` (evaluated as a template)   |
+| `queryFrontend.tolerations`                     | Thanos Query Frontend tolerations for pod assignment                                                                          | `[]` (evaluated as a template)   |
+| `queryFrontend.priorityClassName`               | Controller priorityClassName                                                                           | `nil`                                                   |
+| `queryFrontend.securityContext.enabled`         | Enable security context for Thanos Query Frontend pods                                                 | `true`                                                  |
+| `queryFrontend.securityContext.fsGroup`         | Group ID for the Thanos Query Frontend filesystem                                                      | `1001`                                                  |
+| `queryFrontend.securityContext.runAsUser`       | User ID for the Thanos queryFrontend container                                                         | `1001`                                                  |
+| `queryFrontend.resources.limits`                | The resources limits for the Thanos Query Frontend container                                           | `{}`                                                    |
+| `queryFrontend.resources.requests`              | The requested resources for the Thanos Query Frontend container                                        | `{}`                                                    |
+| `queryFrontend.podAnnotations`                  | Annotations for Thanos Query Frontend pods                                                             | `{}`                                                    |
+| `queryFrontend.livenessProbe`                   | Liveness probe configuration for Thanos Query Frontend                                                 | `Check values.yaml file`                                |
+| `queryFrontend.readinessProbe`                  | Readiness probe configuration for Thanos Query Frontend                                                | `Check values.yaml file`                                |
+| `queryFrontend.service.type`                    | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `queryFrontend.service.clusterIP`               | Thanos Query Frontend  service clusterIP IP                                                            | `None`                                                  |
+| `queryFrontend.service.http.port`               | Service HTTP port                                                                                      | `9090`                                                  |
+| `queryFrontend.service.http.nodePort`           | Service HTTP node port                                                                                 | `nil`                                                   |
+| `queryFrontend.service.loadBalancerIP`          | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `queryFrontend.service.loadBalancerSourceRanges`| Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `queryFrontend.service.annotations`             | Annotations for Thanos Query Frontend service                                                          | `{}`                                                    |
+| `queryFrontend.service.labelSelectorsOverride`  | Selector for Thanos query service                                                                      | `{}`                                                    |
+| `queryFrontend.serviceAccount.annotations`      | Annotations for Thanos Query Frontend Service Account                                                  | `{}`                                                    |
+| `queryFrontend.rbac.create`                     | Create RBAC                                                                                            | `false`                                                 |
+| `queryFrontend.pspEnabled`                      | Create PodSecurityPolicy                                                                               | `false`                                                 |
+| `queryFrontend.autoscaling.enabled`             | Enable autoscaling for Thanos Query Frontend                                                           | `false`                                                 |
+| `queryFrontend.autoscaling.minReplicas`         | Minimum number of Thanos Query Frontend replicas                                                       | `nil`                                                   |
+| `queryFrontend.autoscaling.maxReplicas`         | Maximum number of Thanos Query Frontend replicas                                                       | `nil`                                                   |
+| `queryFrontend.autoscaling.targetCPU`           | Target CPU utilization percentage                                                                      | `nil`                                                   |
+| `queryFrontend.autoscaling.targetMemory`        | Target Memory utilization percentage                                                                   | `nil`                                                   |
+| `queryFrontend.pdb.create`                      | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `queryFrontend.pdb.minAvailable`                | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `queryFrontend.pdb.maxUnavailable`              | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `queryFrontend.ingress.enabled`                 | Enable ingress controller resource                                                                     | `false`                                                 |
+| `queryFrontend.ingress.apiVersion`              | Force Ingress API version (automatically detected if not set)                                          | ``                                                      |
+| `queryFrontend.ingress.path`                    | Ingress path                                                                                           | `/`                                                     |
+| `queryFrontend.ingress.pathType`                | Ingress path type                                                                                      | `ImplementationSpecific`                                |
+| `queryFrontend.ingress.certManager`             | Add annotations for cert-manager                                                                       | `false`                                                 |
+| `queryFrontend.ingress.hostname`                | Default host for the ingress resource                                                                  | `thanos.local`                                          |
+| `queryFrontend.ingress.annotations`             | Ingress annotations                                                                                    | `[]`                                                    |
+| `queryFrontend.ingress.extraHosts[0].name`      | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `queryFrontend.ingress.extraHosts[0].path`      | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `queryFrontend.ingress.extraTls[0].hosts[0]`    | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `queryFrontend.ingress.extraTls[0].secretName`  | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `queryFrontend.ingress.secrets[0].name`         | TLS Secret Name                                                                                        | `nil`                                                   |
+| `queryFrontend.ingress.secrets[0].certificate`  | TLS Secret Certificate                                                                                 | `nil`                                                   |
+| `queryFrontend.ingress.secrets[0].key`          | TLS Secret Key                                                                                         | `nil`                                                   |
+
+### Thanos Bucket Web parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `bucketweb.enabled`                                  | Enable/disable Thanos Bucket Web component                                                             | `false`                                                 |
+| `bucketweb.logLevel`                                 | Thanos Bucket Web log level                                                                            | `info`                                                  |
+| `bucketweb.refresh`                                  | Refresh interval to download metadata from remote storage                                              | `30m`                                                   |
+| `bucketweb.timeout`                                  | Timeout to download metadata from remote storage                                                       | `5m`                                                    |
+| `bucketweb.extraFlags`                               | Extra Flags to passed to Thanos Bucket Web                                                             | `[]`                                                    |
+| `bucketweb.replicaCount`                             | Number of Thanos Bucket Web replicas to deploy                                                         | `1`                                                     |
+| `bucketweb.strategyType`                             | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
+| `bucketweb.podAntiAffinityPreset`                    | Thanos Bucket Web pod anti-affinity preset. Ignored if `bucketweb.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                   |
+| `bucketweb.nodeAffinityPreset.type`                  | Thanos Bucket Web node affinity preset type. Ignored if `bucketweb.affinity` is set. Allowed values: `soft` or `hard` | `""`                                     |
+| `bucketweb.nodeAffinityPreset.key`                   | Thanos Bucket Web node label key to match Ignored if `bucketweb.affinity` is set.                                     | `""`                                     |
+| `bucketweb.nodeAffinityPreset.values`                | Thanos Bucket Web node label values to match. Ignored if `bucketweb.affinity` is set.                                 | `[]`                                     |
+| `bucketweb.affinity`                                 | Thanos Bucket Web affinity for pod assignment                                                                         | `{}` (evaluated as a template)           |
+| `bucketweb.nodeSelector`                             | Thanos Bucket Web node labels for pod assignment                                                                      | `{}` (evaluated as a template)           |
+| `bucketweb.tolerations`                              | Thanos Bucket Web tolerations for pod assignment                                                                      | `[]` (evaluated as a template)           |
+| `bucketweb.priorityClassName`                        | Controller priorityClassName                                                                           | `nil`                                                   |
+| `bucketweb.securityContext.enabled`                  | Enable security context for Thanos Bucket Web pods                                                     | `true`                                                  |
+| `bucketweb.securityContext.fsGroup`                  | Group ID for the Thanos Bucket Web filesystem                                                          | `1001`                                                  |
+| `bucketweb.securityContext.runAsUser`                | User ID for the Thanos Bucket Web container                                                            | `1001`                                                  |
+| `bucketweb.resources.limits`                         | The resources limits for the Thanos Bucket Web container                                               | `{}`                                                    |
+| `bucketweb.resources.requests`                       | The requested resources for the Thanos Bucket Web container                                            | `{}`                                                    |
+| `bucketweb.podAnnotations`                           | Annotations for Thanos Bucket Web pods                                                                 | `{}`                                                    |
+| `bucketweb.livenessProbe`                            | Liveness probe configuration for Thanos Compactor                                                      | `Check values.yaml file`                                |
+| `bucketweb.readinessProbe`                           | Readiness probe configuration for Thanos Compactor                                                     | `Check values.yaml file`                                |
+| `bucketweb.service.type`                             | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `bucketweb.service.clusterIP`                        | Thanos Bucket Web service clusterIP IP                                                                 | `None`                                                  |
+| `bucketweb.service.http.port`                        | Service HTTP port                                                                                      | `8080`                                                  |
+| `bucketweb.service.http.nodePort`                    | Service HTTP node port                                                                                 | `nil`                                                   |
+| `bucketweb.service.loadBalancerIP`                   | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `bucketweb.service.loadBalancerSourceRanges`         | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `bucketweb.service.annotations`                      | Annotations for Thanos Bucket Web service                                                              | `{}`                                                    |
+| `bucketweb.service.labelSelectorsOverride`           | Selector for Thanos query service                                                                      | `{}`                                                    |
+| `bucketweb.serviceAccount.annotations`               | Annotations for Thanos Bucket Web Service Account                                                      | `{}`                                                    |
+| `bucketweb.serviceAccount.existingServiceAccount`    | Name for an existing Thanos Bucket Web Service Account                                                 | `nil`                                                   |
+| `bucketweb.pdb.create`                               | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `bucketweb.pdb.minAvailable`                         | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `bucketweb.pdb.maxUnavailable`                       | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `bucketweb.ingress.enabled`                          | Enable ingress controller resource                                                                     | `false`                                                 |
+| `bucketweb.ingress.apiVersion`                       | Force Ingress API version (automatically detected if not set)                                          | ``                                                      |
+| `bucketweb.ingress.path`                             | Ingress path                                                                                           | `/`                                                     |
+| `bucketweb.ingress.pathType`                         | Ingress path type                                                                                      | `ImplementationSpecific`                                |
+| `bucketweb.ingress.certManager`                      | Add annotations for cert-manager                                                                       | `false`                                                 |
+| `bucketweb.ingress.hostname`                         | Default host for the ingress resource                                                                  | `thanos-bucketweb.local`                                |
+| `bucketweb.ingress.annotations`                      | Ingress annotations                                                                                    | `[]`                                                    |
+| `bucketweb.ingress.tls`                              | Create ingress TLS section                                                                             | `false`                                                 |
+| `bucketweb.ingress.extraHosts[0].name`               | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `bucketweb.ingress.extraHosts[0].path`               | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `bucketweb.ingress.extraTls[0].hosts[0]`             | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `bucketweb.ingress.extraTls[0].secretName`           | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `bucketweb.ingress.secrets[0].name`                  | TLS Secret Name                                                                                        | `nil`                                                   |
+| `bucketweb.ingress.secrets[0].certificate`           | TLS Secret Certificate                                                                                 | `nil`                                                   |
+| `bucketweb.ingress.secrets[0].key`                   | TLS Secret Key                                                                                         | `nil`                                                   |
+
+### Thanos Compactor parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `compactor.enabled`                                  | Enable/disable Thanos Compactor component                                                              | `false`                                                 |
+| `compactor.logLevel`                                 | Thanos Compactor log level                                                                             | `info`                                                  |
+| `compactor.retentionResolutionRaw`                   | Resolution and Retention flag                                                                          | `30d`                                                   |
+| `compactor.retentionResolution5m`                    | Resolution and Retention flag                                                                          | `30d`                                                   |
+| `compactor.retentionResolution1h`                    | Resolution and Retention flag                                                                          | `10y`                                                   |
+| `compactor.consistencyDelay`                         | Minimum age of fresh blocks before they are being processed                                            | `30m`                                                   |
+| `compactor.extraFlags`                               | Extra Flags to passed to Thanos Compactor                                                              | `[]`                                                    |
+| `compactor.strategyType`                             | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
+| `compactor.podAntiAffinityPreset`                    | Thanos Compactor pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                    |
+| `compactor.nodeAffinityPreset.type`                  | Thanos Compactor node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard` | `""`                                      |
+| `compactor.nodeAffinityPreset.key`                   | Thanos Compactor node label key to match Ignored if `compactor.affinity` is set.                                     | `""`                                      |
+| `compactor.nodeAffinityPreset.values`                | Thanos Compactor node label values to match. Ignored if `compactor.affinity` is set.                                 | `[]`                                      |
+| `compactor.affinity`                                 | Thanos Compactor affinity for pod assignment                                                                         | `{}` (evaluated as a template)            |
+| `compactor.nodeSelector`                             | Thanos Compactor node labels for pod assignment                                                                      | `{}` (evaluated as a template)            |
+| `compactor.tolerations`                              | Thanos Compactor tolerations for pod assignment                                                                      | `[]` (evaluated as a template)            |
+| `compactor.priorityClassName`                        | Controller priorityClassName                                                                           | `nil`                                                   |
+| `compactor.securityContext.enabled`                  | Enable security context for Thanos Compactor pods                                                      | `true`                                                  |
+| `compactor.securityContext.fsGroup`                  | Group ID for the Thanos Compactor filesystem                                                           | `1001`                                                  |
+| `compactor.securityContext.runAsUser`                | User ID for the Thanos Compactor container                                                             | `1001`                                                  |
+| `compactor.resources.limits`                         | The resources limits for the Thanos Compactor container                                                | `{}`                                                    |
+| `compactor.resources.requests`                       | The requested resources for the Thanos Compactor container                                             | `{}`                                                    |
+| `compactor.podAnnotations`                           | Annotations for Thanos Compactor pods                                                                  | `{}`                                                    |
+| `compactor.livenessProbe`                            | Liveness probe configuration for Thanos Compactor                                                      | `Check values.yaml file`                                |
+| `compactor.readinessProbe`                           | Readiness probe configuration for Thanos Compactor                                                     | `Check values.yaml file`                                |
+| `compactor.service.type`                             | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `compactor.service.clusterIP`                        | Thanos Compactor service clusterIP IP                                                                  | `None`                                                  |
+| `compactor.service.http.port`                        | Service HTTP port                                                                                      | `9090`                                                  |
+| `compactor.service.http.nodePort`                    | Service HTTP node port                                                                                 | `nil`                                                   |
+| `compactor.service.loadBalancerIP`                   | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `compactor.service.loadBalancerSourceRanges`         | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `compactor.service.annotations`                      | Annotations for Thanos Compactor service                                                               | `{}`                                                    |
+| `compactor.service.labelSelectorsOverride`          | Selector for Thanos query service                                                                       | `{}`                                                    |
+| `compactor.serviceAccount.annotations`               | Annotations for Thanos Compactor Service Account                                                       | `{}`                                                    |
+| `compactor.serviceAccount.existingServiceAccount`    | Name for an existing Thanos Compactor Service Account                                                  | `nil`                                                   |
+| `compactor.persistence.enabled`                      | Enable data persistence                                                                                | `true`                                                  |
+| `compactor.persistence.existingClaim`                | Use a existing PVC which must be created manually before bound                                         | `nil`                                                   |
+| `compactor.persistence.storageClass`                 | Specify the `storageClass` used to provision the volume                                                | `nil`                                                   |
+| `compactor.persistence.accessModes`                  | Access modes of data volume                                                                            | `["ReadWriteOnce"]`                                     |
+| `compactor.persistence.size`                         | Size of data volume                                                                                    | `8Gi`                                                   |
+
+### Thanos Store Gateway parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `storegateway.enabled`                               | Enable/disable Thanos Store Gateway component                                                          | `false`                                                 |
+| `storegateway.logLevel`                              | Thanos Store Gateway log level                                                                         | `info`                                                  |
+| `storegateway.extraFlags`                            | Extra Flags to passed to Thanos Store Gateway                                                          | `[]`                                                    |
+| `storegateway.config`                                | Thanos Store Gateway cache configuration                                                               | `nil`                                                   |
+| `storegateway.existingConfigmap`                     | Name of existing ConfigMap with Thanos Store Gateway cache configuration                               | `nil`                                                   |
+| `storegateway.updateStrategyType`                    | Statefulset Update Strategy Type                                                                       | `RollingUpdate`                                         |
+| `storegateway.podManagementPolicy`                   | Statefulset Pod Management Policy Type                                                                 | `OrderedReady`                                          |
+| `storegateway.replicaCount`                          | Number of Thanos Store Gateway replicas to deploy                                                      | `1`                                                     |
+| `storegateway.podAntiAffinityPreset`                 | Thanos Store Gateway pod anti-affinity preset. Ignored if `storegateway.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                             |
+| `storegateway.nodeAffinityPreset.type`               | Thanos Store Gateway node affinity preset type. Ignored if `storegateway.affinity` is set. Allowed values: `soft` or `hard` | `""`                               |
+| `storegateway.nodeAffinityPreset.key`                | Thanos Store Gateway node label key to match Ignored if `storegateway.affinity` is set.                                     | `""`                               |
+| `storegateway.nodeAffinityPreset.values`             | Thanos Store Gateway node label values to match. Ignored if `storegateway.affinity` is set.                                 | `[]`                               |
+| `storegateway.affinity`                              | Thanos Store Gateway affinity for pod assignment                                                                            | `{}` (evaluated as a template)     |
+| `storegateway.nodeSelector`                          | Thanos Store Gateway node labels for pod assignment                                                                         | `{}` (evaluated as a template)     |
+| `storegateway.tolerations`                           | Thanos Store Gateway tolerations for pod assignment                                                                         | `[]` (evaluated as a template)     |
+| `storegateway.priorityClassName`                     | Controller priorityClassName                                                                           | `nil`                                                   |
+| `storegateway.securityContext.enabled`               | Enable security context for Thanos Store Gateway pods                                                  | `true`                                                  |
+| `storegateway.securityContext.fsGroup`               | Group ID for the Thanos Store Gateway filesystem                                                       | `1001`                                                  |
+| `storegateway.securityContext.runAsUser`             | User ID for the Thanos Store Gateway container                                                         | `1001`                                                  |
+| `storegateway.resources.limits`                      | The resources limits for the Thanos Store Gateway container                                            | `{}`                                                    |
+| `storegateway.resources.requests`                    | The requested resources for the Thanos Store Gateway container                                         | `{}`                                                    |
+| `storegateway.podAnnotations`                        | Annotations for Thanos Store Gateway pods                                                              | `{}`                                                    |
+| `storegateway.livenessProbe`                         | Liveness probe configuration for Thanos Store Gateway                                                  | `Check values.yaml file`                                |
+| `storegateway.readinessProbe`                        | Readiness probe configuration for Thanos Store Gateway                                                 | `Check values.yaml file`                                |
+| `storegateway.service.type`                          | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `storegateway.service.clusterIP`                     | Thanos Store Gateway service clusterIP IP                                                              | `None`                                                  |
+| `storegateway.service.http.port`                     | Service HTTP port                                                                                      | `9090`                                                  |
+| `storegateway.service.http.nodePort`                 | Service HTTP node port                                                                                 | `nil`                                                   |
+| `storegateway.service.grpc.port`                     | Service GRPC port                                                                                      | `10901`                                                 |
+| `storegateway.service.grpc.nodePort`                 | Service GRPC node port                                                                                 | `nil`                                                   |
+| `storegateway.service.loadBalancerIP`                | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `storegateway.service.loadBalancerSourceRanges`      | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `storegateway.service.annotations`                   | Annotations for Thanos Store Gateway service                                                           | `{}`                                                    |
+| `storegateway.service.labelSelectorsOverride`        | Selector for Thanos query service                                                                      | `{}`                                                    |
+| `storegateway.service.additionalHeadless`            | Additional Headless service                                                                            | `false`                                                 |
+| `storegateway.serviceAccount.annotations`            | Annotations for Thanos Store Gateway Service Account                                                   | `{}`                                                    |
+| `storegateway.serviceAccount.existingServiceAccount` | Name for an existing Thanos Store Gateway Service Account                                              | `nil`                                                   |
+| `storegateway.persistence.enabled`                   | Enable data persistence                                                                                | `true`                                                  |
+| `storegateway.persistence.existingClaim`             | Use a existing PVC which must be created manually before bound                                         | `nil`                                                   |
+| `storegateway.persistence.storageClass`              | Specify the `storageClass` used to provision the volume                                                | `nil`                                                   |
+| `storegateway.persistence.accessModes`               | Access modes of data volume                                                                            | `["ReadWriteOnce"]`                                     |
+| `storegateway.persistence.size`                      | Size of data volume                                                                                    | `8Gi`                                                   |
+| `storegateway.autoscaling.enabled`                   | Enable autoscaling for Thanos Store Gateway                                                            | `false`                                                 |
+| `storegateway.autoscaling.minReplicas`               | Minimum number of Thanos Store Gateway replicas                                                        | `nil`                                                   |
+| `storegategay.autoscaling.maxReplicas`               | Maximum number of Thanos Store Gateway replicas                                                        | `nil`                                                   |
+| `storegateway.autoscaling.targetCPU`                 | Target CPU utilization percentage                                                                      | `nil`                                                   |
+| `storegateway.autoscaling.targetMemory`              | Target Memory utilization percentage                                                                   | `nil`                                                   |
+| `storegateway.pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `storegateway.pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `storegateway.pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+
+### Thanos Ruler parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `ruler.enabled`                                      | Enable/disable Thanos Ruler component                                                                  | `false`                                                 |
+| `ruler.logLevel`                                     | Thanos Ruler log level                                                                                 | `info`                                                  |
+| `ruler.dnsDiscovery.enabled`                         | Enable Query APIs discovery via DNS                                                                    | `true`                                                  |
+| `ruler.alertmanagers`                                | Alermanager URLs array                                                                                 | `[]`                                                    |
+| `ruler.evalInterval`                                 | The default evaluation interval to use                                                                 | `1m`                                                    |
+| `ruler.clusterName`                                  | Used to set the 'ruler_cluster' label                                                                  | `nil`                                                   |
+| `ruler.extraFlags`                                   | Extra Flags to passed to Thanos Ruler                                                                  | `[]`                                                    |
+| `ruler.config`                                       | Ruler configuration                                                                                    | `nil`                                                   |
+| `ruler.existingConfigmap`                            | Name of existing ConfigMap with Ruler configuration                                                    | `nil`                                                   |
+| `ruler.updateStrategyType`                           | Statefulset Update Strategy Type                                                                       | `RollingUpdate`                                         |
+| `ruler.podManagementPolicy`                          | Statefulset Pod Management Policy Type                                                                 | `OrderedReady`                                          |
+| `ruler.replicaCount`                                 | Number of Thanos Ruler replicas to deploy                                                              | `1`                                                     |
+| `ruler.podAntiAffinityPreset`                        | Thanos Ruler pod anti-affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                            |
+| `ruler.nodeAffinityPreset.type`                      | Thanos Ruler node affinity preset type. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard` | `""`                                              |
+| `ruler.nodeAffinityPreset.key`                       | Thanos Ruler node label key to match Ignored if `ruler.affinity` is set.                                     | `""`                                              |
+| `ruler.nodeAffinityPreset.values`                    | Thanos Ruler node label values to match. Ignored if `ruler.affinity` is set.                                 | `[]`                                              |
+| `ruler.affinity`                                     | Thanos Ruler affinity for pod assignment                                                                     | `{}` (evaluated as a template)                    |
+| `ruler.nodeSelector`                                 | Thanos Ruler node labels for pod assignment                                                                  | `{}` (evaluated as a template)                    |
+| `ruler.tolerations`                                  | Thanos Ruler tolerations for pod assignment                                                                  | `[]` (evaluated as a template)                    |
+| `ruler.priorityClassName`                            | Controller priorityClassName                                                                           | `nil`                                                   |
+| `ruler.securityContext.enabled`                      | Enable security context for Thanos Ruler pods                                                          | `true`                                                  |
+| `ruler.securityContext.fsGroup`                      | Group ID for the Thanos Ruler filesystem                                                               | `1001`                                                  |
+| `ruler.securityContext.runAsUser`                    | User ID for the Thanos Ruler container                                                                 | `1001`                                                  |
+| `ruler.resources.limits`                             | The resources limits for the Thanos Ruler container                                                    | `{}`                                                    |
+| `ruler.resources.requests`                           | The requested resources for the Thanos Ruler container                                                 | `{}`                                                    |
+| `ruler.podAnnotations`                               | Annotations for Thanos Ruler pods                                                                      | `{}`                                                    |
+| `ruler.livenessProbe`                                | Liveness probe configuration for Thanos Ruler                                                          | `Check values.yaml file`                                |
+| `ruler.readinessProbe`                               | Readiness probe configuration for Thanos Ruler                                                         | `Check values.yaml file`                                |
+| `ruler.service.type`                                 | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `ruler.service.clusterIP`                            | Thanos Ruler service clusterIP IP                                                                      | `None`                                                  |
+| `ruler.service.http.port`                            | Service HTTP port                                                                                      | `9090`                                                  |
+| `ruler.service.http.nodePort`                        | Service HTTP node port                                                                                 | `nil`                                                   |
+| `ruler.service.grpc.port`                            | Service GRPC port                                                                                      | `10901`                                                 |
+| `ruler.service.grpc.nodePort`                        | Service GRPC node port                                                                                 | `nil`                                                   |
+| `ruler.service.loadBalancerIP`                       | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `ruler.service.loadBalancerSourceRanges`             | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `ruler.service.annotations`                          | Annotations for Thanos Ruler service                                                                   | `{}`                                                    |
+| `ruler.service.labelSelectorsOverride`        | Selector for Thanos query service                                                                             | `{}`                                                    |
+| `ruler.service.additionalHeadless`                   | Additional Headless service                                                                            | `false`                                                 |
+| `ruler.serviceAccount.annotations`                   | Annotations for Thanos Ruler Service Account                                                           | `{}`                                                    |
+| `ruler.serviceAccount.existingServiceAccount`        | Name for an existing Thanos Ruler Service Account                                                      | `nil`                                                   |
+| `ruler.persistence.enabled`                          | Enable data persistence                                                                                | `true`                                                  |
+| `ruler.persistence.existingClaim`                    | Use a existing PVC which must be created manually before bound                                         | `nil`                                                   |
+| `ruler.persistence.storageClass`                     | Specify the `storageClass` used to provision the volume                                                | `nil`                                                   |
+| `ruler.persistence.accessModes`                      | Access modes of data volume                                                                            | `["ReadWriteOnce"]`                                     |
+| `ruler.persistence.size`                             | Size of data volume                                                                                    | `8Gi`                                                   |
+| `ruler.pdb.create`                                   | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `ruler.pdb.minAvailable`                             | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `ruler.pdb.maxUnavailable`                           | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+
+### Metrics parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `metrics.enabled`                                    | Enable the export of Prometheus metrics                                                                | `false`                                                 |
+| `metrics.serviceMonitor.enabled`                     | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
+| `metrics.serviceMonitor.namespace`                   | Namespace in which Prometheus is running                                                               | `nil`                                                   |
+| `metrics.serviceMonitor.labels`                      | Additional labels for ServiceMonitor                                                                   | `{}`                                                    |
+| `metrics.serviceMonitor.interval`                    | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
+| `metrics.serviceMonitor.scrapeTimeout`               | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
+
+### Volume Permissions parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `volumePermissions.enabled`           | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                                                 |
+| `volumePermissions.image.registry`    | Init container volume-permissions image registry                                                                     | `docker.io`                                             |
+| `volumePermissions.image.repository`  | Init container volume-permissions image name                                                                         | `bitnami/minideb`                                       |
+| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                                          | `buster`                                                |
+| `volumePermissions.image.pullPolicy`  | Init container volume-permissions image pull policy                                                                  | `Always`                                                |
+| `volumePermissions.image.pullSecrets` | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods) |
+
+### MinIO<sup>TM</sup> chart parameters
+
+| Parameter                                            | Description                                                                                            | Default                                                 |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `minio.enabled`                                      | Enable/disable MinIO<sup>TM</sup> chart installation                                                   | `false`                                                 |
+| `minio.accessKey.password`                           | MinIO<sup>TM</sup> Access Key                                                                          | _random 10 character alphanumeric string_               |
+| `minio.secretKey.password`                           | MinIO<sup>TM</sup> Secret Key                                                                          | _random 40 character alphanumeric string_               |
+| `minio.defaultBuckets`                               | Comma, semi-colon or space separated list of buckets to create                                         | `nil`                                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install my-release --set query.replicaCount=2 bitnami/thanos
+```
+
+The above command install Thanos chart with 2 Thanos Query replicas.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install my-release -f values.yaml bitnami/thanos
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Production configuration
+
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
+
+- Enable Thanos Compactor:
+
+```diff
+- compactor.enabled: false
++ compactor.enabled: true
+```
+
+- Enable Thanos Store Gateway:
+
+```diff
+- storegateway.enabled: false
++ storegateway.enabled: true
+```
+
+- Enable Thanos Ruler:
+
+```diff
+- ruler.enabled: false
++ ruler.enabled: true
+```
+
+- Enable Prometheus Metrics:
+
+```diff
+- metrics.enabled: false
++ metrics.enabled: true
+- metrics.serviceMonitor: false
++ metrics.serviceMonitor: true
+```
+
+### Adding extra flags
+
+In case you want to add extra flags to any Thanos component, you can use `XXX.extraFlags` parameter(s), where XXX is placeholder you need to replace with the actual component(s). For instance, to add extra flags to Thanos Store Gateway, use:
+
+```yaml
+storegateway:
+  extraFlags:
+    - --sync-block-duration=3m
+    - --chunk-pool-size=2GB
+```
+
+This also works for multi-line flags. This can be useful when you want to configure caching for a particular component without using a configMap. For example, to configure the [query-range response cache of the Thanos Query Frontend](https://thanos.io/tip/components/query-frontend.md/#memcached), use:
+
+```yaml
+queryFrontend:
+  extraFlags:
+    - |
+      --query-range.response-cache-config=
+      type: MEMCACHED
+      config:
+        addresses:
+          - <MEMCACHED_SERVER>:11211
+        timeout: 500ms
+        max_idle_connections: 100
+        max_async_concurrency: 10
+        max_async_buffer_size: 10000
+        max_get_multi_concurrency: 100
+        max_get_multi_batch_size: 0
+        dns_provider_update_interval: 10s
+        expiration: 24h
+```
+
+### Using custom Objstore configuration
+
+This helm chart supports using custom Objstore configuration.
+
+You can specify the Objstore configuration using the `objstoreConfig` parameter.
+
+In addition, you can also set an external Secret with the configuration file. This is done by setting the `existingObjstoreSecret` parameter. Note that this will override the previous option. If needed you can also provide a custom Secret Key with `existingObjstoreSecretItems`, please be aware that the Path of your Secret should be `objstore.yml`.
+
+### Using custom Query Service Discovery configuration
+
+This helm chart supports using custom Service Discovery configuration for Query.
+
+You can specify the Service Discovery configuration using the `query.sdConfig` parameter.
+
+In addition, you can also set an external ConfigMap with the Service Discovery configuration file. This is done by setting the `query.existingSDConfigmap` parameter. Note that this will override the previous option.
+
+### Using custom Ruler configuration
+
+This helm chart supports using custom Ruler configuration.
+
+You can specify the Ruler configuration using the `ruler.config` parameter.
+
+In addition, you can also set an external ConfigMap with the configuration file. This is done by setting the `ruler.existingConfigmap` parameter. Note that this will override the previous option.
+
+### Integrate Thanos with Prometheus and Alertmanager
+
+You can intregrate Thanos with Prometheus & Alertmanager using this chart and the [Bitnami kube-prometheus chart](https://github.com/bitnami/charts/tree/master/bitnami/kube-prometheus) following the steps below:
+
+> Note: in this example we will use MinIO (subchart) as the Objstore. Every component will be deployed in the "monitoring" namespace.
+
+- Create a **values.yaml** like the one below:
+
+```yaml
+objstoreConfig: |-
+  type: s3
+  config:
+    bucket: thanos
+    endpoint: {{ include "thanos.minio.fullname" . }}.monitoring.svc.cluster.local:9000
+    access_key: minio
+    secret_key: minio123
+    insecure: true
+query:
+  dnsDiscovery:
+    sidecarsService: kube-prometheus-prometheus-thanos
+    sidecarsNamespace: monitoring
+bucketweb:
+  enabled: true
+compactor:
+  enabled: true
+storegateway:
+  enabled: true
+ruler:
+  enabled: true
+  alertmanagers:
+    - http://kube-prometheus-alertmanager.monitoring.svc.cluster.local:9093
+  config: |-
+    groups:
+      - name: "metamonitoring"
+        rules:
+          - alert: "PrometheusDown"
+            expr: absent(up{prometheus="monitoring/kube-prometheus"})
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+minio:
+  enabled: true
+  accessKey:
+    password: "minio"
+  secretKey:
+    password: "minio123"
+  defaultBuckets: "thanos"
+```
+
+- Install Prometheus Operator and Thanos charts:
+
+For Helm 3:
+
+```bash
+kubectl create namespace monitoring
+helm install kube-prometheus \
+    --set prometheus.thanos.create=true \
+    --namespace monitoring \
+    bitnami/kube-prometheus
+helm install thanos \
+    --values values.yaml \
+    --namespace monitoring \
+    bitnami/thanos
+```
+
+That's all! Now you have Thanos fully integrated with Prometheus and Alertmanager.
+
+## Persistence
+
+The data is persisted by default using PVC(s) on Thanos components. You can disable the persistence setting the `XXX.persistence.enabled` parameter(s) to `false`. A default `StorageClass` is needed in the Kubernetes cluster to dynamically provision the volumes. Specify another StorageClass in the `XXX.persistence.storageClass` parameter(s) or set `XXX.persistence.existingClaim` if you have already existing persistent volumes to use.
+
+> Note: you need to substitute the XXX placeholders above with the actual component(s) you want to configure.
+
+### Adjust permissions of persistent volume mountpoint
+
+As the images run as non-root by default, it is necessary to adjust the ownership of the persistent volumes so that the containers can write data into it.
+
+By default, the chart is configured to use Kubernetes Security Context to automatically change the ownership of the volumes. However, this feature does not work in all Kubernetes distributions.
+As an alternative, this chart supports using an initContainer to change the ownership of the volumes before mounting it in the final destination.
+
+You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
+
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `XXX.affinity` parameter(s). Find more information about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `XXX.podAffinityPreset`, `XXX.podAntiAffinityPreset`, or `XXX.nodeAffinityPreset` parameters.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 3.3.0
+
+This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+### To 3.1.0
+
+The querier component and its settings have been renamed to query. Configuration of the query component by using keys under `querier` in your `values.yaml` will continue to work. Support for keys under `querier` will be dropped in a future release.
+
+```
+querier.enabled                               -> query.enabled
+querier.logLevel                              -> query.logLevel
+querier.replicaLabel                          -> query.replicaLabel
+querier.dnsDiscovery.enabled                  -> query.dnsDiscovery.enabled
+querier.dnsDiscovery.sidecarsService          -> query.dnsDiscovery.sidecarsService
+querier.dnsDiscovery.sidecarsNamespace        -> query.dnsDiscovery.sidecarsNamespace
+querier.stores                                -> query.stores
+querier.sdConfig                              -> query.sdConfig
+querier.existingSDConfigmap                   -> query.existingSDConfigmap
+querier.extraFlags                            -> query.extraFlags
+querier.replicaCount                          -> query.replicaCount
+querier.strategyType                          -> query.strategyType
+querier.affinity                              -> query.affinity
+querier.nodeSelector                          -> query.nodeSelector
+querier.tolerations                           -> query.tolerations
+querier.priorityClassName                     -> query.priorityClassName
+querier.securityContext.enabled               -> query.securityContext.enabled
+querier.securityContext.fsGroup               -> query.securityContext.fsGroup
+querier.securityContext.runAsUser             -> query.securityContext.runAsUser
+querier.resources.limits                      -> query.resources.limits
+querier.resources.requests                    -> query.resources.requests
+querier.podAnnotations                        -> query.podAnnotations
+querier.livenessProbe                         -> query.livenessProbe
+querier.readinessProbe                        -> query.readinessProbe
+querier.grpcTLS.server.secure                 -> query.grpcTLS.server.secure
+querier.grpcTLS.server.cert                   -> query.grpcTLS.server.cert
+querier.grpcTLS.server.key                    -> query.grpcTLS.server.key
+querier.grpcTLS.server.ca                     -> query.grpcTLS.server.ca
+querier.grpcTLS.client.secure                 -> query.grpcTLS.client.secure
+querier.grpcTLS.client.cert                   -> query.grpcTLS.client.cert
+querier.grpcTLS.client.key                    -> query.grpcTLS.client.key
+querier.grpcTLS.client.ca                     -> query.grpcTLS.client.ca
+querier.grpcTLS.client.servername             -> query.grpcTLS.client.servername
+querier.service.type                          -> query.service.type
+querier.service.clusterIP                     -> query.service.clusterIP
+querier.service.http.port                     -> query.service.http.port
+querier.service.http.nodePort                 -> query.service.http.nodePort
+querier.service.grpc.port                     -> query.service.grpc.port
+querier.service.grpc.nodePort                 -> query.service.grpc.nodePort
+querier.service.loadBalancerIP                -> query.service.loadBalancerIP
+querier.service.loadBalancerSourceRanges      -> query.service.loadBalancerSourceRanges
+querier.service.annotations                   -> query.service.annotations
+querier.service.labelSelectorsOverride        -> query.service.labelSelectorsOverride
+querier.serviceAccount.annotations            -> query.serviceAccount.annotations
+querier.rbac.create                           -> query.rbac.create
+querier.pspEnabled                            -> query.pspEnabled
+querier.autoscaling.enabled                   -> query.autoscaling.enabled
+querier.autoscaling.minReplicas               -> query.autoscaling.minReplicas
+querier.autoscaling.maxReplicas               -> query.autoscaling.maxReplicas
+querier.autoscaling.targetCPU                 -> query.autoscaling.targetCPU
+querier.autoscaling.targetMemory              -> query.autoscaling.targetMemory
+querier.pdb.create                            -> query.pdb.create
+querier.pdb.minAvailable                      -> query.pdb.minAvailable
+querier.pdb.maxUnavailable                    -> query.pdb.maxUnavailable
+querier.ingress.enabled                       -> query.ingress.enabled
+querier.ingress.certManager                   -> query.ingress.certManager
+querier.ingress.hostname                      -> query.ingress.hostname
+querier.ingress.annotations                   -> query.ingress.annotations
+querier.ingress.tls                           -> query.ingress.tls
+querier.ingress.extraHosts[0].name            -> query.ingress.extraHosts[0].name
+querier.ingress.extraHosts[0].path            -> query.ingress.extraHosts[0].path
+querier.ingress.extraTls[0].hosts[0]          -> query.ingress.extraTls[0].hosts[0]
+querier.ingress.extraTls[0].secretName        -> query.ingress.extraTls[0].secretName
+querier.ingress.secrets[0].name               -> query.ingress.secrets[0].name
+querier.ingress.secrets[0].certificate        -> query.ingress.secrets[0].certificate
+querier.ingress.secrets[0].key                -> query.ingress.secrets[0].key
+querier.ingress.grpc.enabled                  -> query.ingress.grpc.enabled
+querier.ingress.grpc.certManager              -> query.ingress.grpc.certManager
+querier.ingress.grpc.hostname                 -> query.ingress.grpc.hostname
+querier.ingress.grpc.annotations              -> query.ingress.grpc.annotations
+querier.ingress.grpc.extraHosts[0].name       -> query.ingress.grpc.extraHosts[0].name
+querier.ingress.grpc.extraHosts[0].path       -> query.ingress.grpc.extraHosts[0].path
+querier.ingress.grpc.extraTls[0].hosts[0]     -> query.ingress.grpc.extraTls[0].hosts[0]
+querier.ingress.grpc.extraTls[0].secretName   -> query.ingress.grpc.extraTls[0].secretName
+querier.ingress.grpc.secrets[0].name          -> query.ingress.grpc.secrets[0].name
+querier.ingress.grpc.secrets[0].certificate   -> query.ingress.grpc.secrets[0].certificate
+querier.ingress.grpc.secrets[0].key           -> query.ingress.grpc.secrets[0].key
+```
+
+### To 3.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+### To 2.4.0
+
+The Ingress API object name for Querier changes from:
+
+```yaml
+{{ include "common.names.fullname" . }}
+```
+
+> **NOTE**: Which in most cases (depending on any set values in `fullnameOverride` or `nameOverride`) resolves to the used Helm release name (`.Release.Name`).
+
+To:
+
+```yaml
+{{ include "common.names.fullname" . }}-querier
+```
+
+### To 2.0.0
+
+The format of the chart's `extraFlags` option has been updated to be an array (instead of an object), to support passing multiple flags with the same name to Thanos.
+
+Now you need to specify the flags in the following way in your values file (where component is one of `querier/bucketweb/compactor/storegateway/ruler`):
+
+```yaml
+component:
+  ...
+  extraFlags
+    - --sync-block-duration=3m
+    - --chunk-pool-size=2GB
+```
+
+To specify the values via CLI::
+
+```console
+--set 'component.extraFlags[0]=--sync-block-duration=3m' --set 'ruler.extraFlags[1]=--chunk-pool-size=2GB'
+```
+
+### To 1.0.0
+
+If you are upgrading from a `<1.0.0` release you need to move your Querier Ingress information to the new values settings:
+```
+ingress.enabled -> querier.ingress.enabled
+ingress.certManager -> querier.ingress.certManager
+ingress.hostname -> querier.ingress.hostname
+ingress.annotations -> querier.ingress.annotations
+ingress.extraHosts[0].name -> querier.ingress.extraHosts[0].name
+ingress.extraHosts[0].path -> querier.ingress.extraHosts[0].path
+ingress.extraHosts[0].hosts[0] -> querier.ingress.extraHosts[0].hosts[0]
+ingress.extraHosts[0].secretName -> querier.ingress.extraHosts[0].secretName
+ingress.secrets[0].name -> querier.ingress.secrets[0].name
+ingress.secrets[0].certificate -> querier.ingress.secrets[0].certificate
+ingress.secrets[0].key -> querier.ingress.secrets[0].key

--- a/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio.yaml
+++ b/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio.yaml
@@ -1,0 +1,28 @@
+# Test values file for generating all of the yaml and check that
+# the rendering is correct
+
+objstoreConfig: |-
+  type: s3
+  config:
+    bucket: thanos
+    endpoint: {{ include "thanos.minio.fullname" . }}.monitoring.svc.cluster.local:9000
+    access_key: minio
+    secret_key: minio123
+    insecure: true
+
+bucketweb:
+  enabled: true
+
+compactor:
+  enabled: true
+
+storegateway:
+  enabled: true
+
+minio:
+  enabled: true
+  accessKey:
+    password: "minio"
+  secretKey:
+    password: "minio123"
+  defaultBuckets: "thanos"

--- a/thanos/ci/values-with-ingress-and-metrics.yaml
+++ b/thanos/ci/values-with-ingress-and-metrics.yaml
@@ -1,0 +1,14 @@
+# Test values file for generating all of the yaml and check that
+# the rendering is correct
+
+ingress:
+  enabled: true
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    ## Enable only if you previously installed the Prometheus Operator 
+    ## in your cluster
+    enabled: true
+    labels:
+      release: prometheus-operator

--- a/thanos/templates/NOTES.txt
+++ b/thanos/templates/NOTES.txt
@@ -1,0 +1,75 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+** Please be patient while the chart is being deployed **
+
+Thanos chart was deployed enabling the following components:
+
+{{- if $query.enabled }}
+- Thanos Query
+{{- end }}
+{{- if .Values.bucketweb.enabled }}
+- Thanos Bucket Web
+{{- end }}
+{{- if .Values.compactor.enabled }}
+- Thanos Compactor
+{{- end }}
+{{- if .Values.ruler.enabled }}
+- Thanos Ruler
+{{- end }}
+{{- if .Values.storegateway.enabled }}
+- Thanos Store Gateway
+{{- end }}
+
+{{- if $query.enabled }}
+
+Thanos Query can be accessed through following DNS name from within your cluster:
+
+    {{ include "common.names.fullname" . }}-query.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ $query.service.http.port }})
+
+To access Thanos Query from outside the cluster execute the following commands:
+
+{{- if $query.ingress.enabled }}
+
+1. Get the Thanos Query URL and associate Thanos Query hostname to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "Thanos Query URL: http{{ if $query.ingress.tls }}s{{ end }}://{{ $query.ingress.hostname }}/"
+   echo "$CLUSTER_IP  {{ $query.ingress.hostname }}" | sudo tee -a /etc/hosts
+
+{{- else }}
+
+1. Get the Thanos Query URL by running these commands:
+
+{{- if contains "NodePort" $query.service.type }}
+
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }}-query)
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "http://${NODE_IP}:${NODE_PORT}"
+
+{{- else if contains "LoadBalancer" $query.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}-query'
+
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }}-query)
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-query -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "http://${SERVICE_IP}:${SERVICE_PORT}"
+
+{{- else if contains "ClusterIP" $query.service.type }}
+
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }}-query)
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }}-query ${SERVICE_PORT}:${SERVICE_PORT} &
+    echo "http://127.0.0.1:${SERVICE_PORT}"
+
+{{- end }}
+{{- end }}
+
+2. Open a browser and access Thanos Query using the obtained URL.
+
+{{- else }}
+
+WARNING: You deployed Thanos without enabling Thanos Query!!
+
+{{- end }}
+
+{{- include "thanos.validateValues" . }}
+{{- include "thanos.checkRollingTags" . }}

--- a/thanos/templates/_helpers.tpl
+++ b/thanos/templates/_helpers.tpl
@@ -1,0 +1,259 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Fully qualified app name for PostgreSQL
+*/}}
+{{- define "thanos.minio.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-minio" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-minio" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-minio" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Thanos image name
+*/}}
+{{- define "thanos.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
+Return the proper init container volume-permissions image name
+*/}}
+{{- define "thanos.volumePermissions.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.volumePermissions "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "thanos.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.volumePermissions.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the Thanos Objstore configuration secret.
+*/}}
+{{- define "thanos.objstoreSecretName" -}}
+{{- if .Values.existingObjstoreSecret -}}
+    {{- printf "%s" (tpl .Values.existingObjstoreSecret $) -}}
+{{- else -}}
+    {{- printf "%s-objstore-secret" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "thanos.createObjstoreSecret" -}}
+{{- if and .Values.objstoreConfig (not .Values.existingObjstoreSecret) }}
+    {{- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return a YAML of either .Values.query or .Values.querier
+If .Values.querier is used, we merge in the defaults from .Values.query, giving preference to .Values.querier
+*/}}
+{{- define "thanos.query.values" -}}
+{{- if .Values.querier -}}
+    {{- if .Values.query -}}
+        {{- mergeOverwrite .Values.query .Values.querier | toYaml -}}
+    {{- else -}}
+        {{- .Values.querier | toYaml -}}
+    {{- end -}}
+{{- else -}}
+    {{- .Values.query | toYaml -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Thanos Query Service Discovery configuration configmap.
+*/}}
+{{- define "thanos.query.SDConfigmapName" -}}
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.existingSDConfigmap -}}
+    {{- printf "%s" (tpl $query.existingSDConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-query-sd-configmap" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created
+*/}}
+{{- define "thanos.query.createSDConfigmap" -}}
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.sdConfig (not $query.existingSDConfigmap) }}
+    {{- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Thanos Ruler configuration configmap.
+*/}}
+{{- define "thanos.ruler.configmapName" -}}
+{{- if .Values.ruler.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.ruler.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-ruler-configmap" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created
+*/}}
+{{- define "thanos.ruler.createConfigmap" -}}
+{{- if and .Values.ruler.config (not .Values.ruler.existingConfigmap) }}
+    {{- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Thanos storegateway configuration configmap.
+*/}}
+{{- define "thanos.storegateway.configmapName" -}}
+{{- if .Values.storegateway.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.storegateway.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-storegateway-configmap" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Thanos Query Frontend configuration configmap.
+*/}}
+{{- define "thanos.queryFrontend.configmapName" -}}
+{{- if .Values.queryFrontend.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.queryFrontend.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-query-frontend-configmap" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created
+*/}}
+{{- define "thanos.queryFrontend.createConfigmap" -}}
+{{- if and .Values.queryFrontend.config (not .Values.queryFrontend.existingConfigmap) }}
+    {{- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created
+*/}}
+{{- define "thanos.storegateway.createConfigmap" -}}
+{{- if and .Values.storegateway.config (not .Values.storegateway.existingConfigmap) }}
+    {{- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Thanos Compactor pvc name
+*/}}
+{{- define "thanos.compactor.pvcName" -}}
+{{- if .Values.compactor.persistence.existingClaim -}}
+    {{- printf "%s" (tpl .Values.compactor.persistence.existingClaim $) -}}
+{{- else -}}
+    {{- printf "%s-compactor" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "thanos.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "thanos.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "thanos.validateValues.objstore" .) -}}
+{{- $messages := append $messages (include "thanos.validateValues.ruler.alertmanagers" .) -}}
+{{- $messages := append $messages (include "thanos.validateValues.ruler.config" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Thanos - Objstore configuration */}}
+{{- define "thanos.validateValues.objstore" -}}
+{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreSecret" .)) ( not .Values.existingObjstoreSecret) -}}
+thanos: objstore configuration
+    When enabling Bucket Web, Compactor, Ruler or Store Gateway component,
+    you must provide a valid objstore configuration.
+    There are three alternatives to provide it:
+      1) Provide it using the 'objstoreConfig' parameter
+      2) Provide it using an existing Secret and using the 'existingObjstoreSecret' parameter
+      3) Put your objstore.yml under the 'files/conf/' directory
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Thanos - Ruler Alertmanager(s) */}}
+{{- define "thanos.validateValues.ruler.alertmanagers" -}}
+{{- if and .Values.ruler.enabled (empty .Values.ruler.alertmanagers) -}}
+thanos: ruler alertmanagers
+    When enabling Ruler component, you must provide alermanagers URL(s).
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Thanos - Ruler configuration */}}
+{{- define "thanos.validateValues.ruler.config" -}}
+{{- if and .Values.ruler.enabled (not (include "thanos.ruler.createConfigmap" .)) (not .Values.ruler.existingConfigmap) -}}
+thanos: ruler configuration
+    When enabling Ruler component, you must provide a valid configuration.
+    There are three alternatives to provide it:
+      1) Provide it using the 'ruler.config' parameter
+      2) Provide it using an existing Configmap and using the 'ruler.existingConfigmap' parameter
+      3) Put your ruler.yml under the 'files/conf/' directory
+{{- end -}}
+{{- end -}}
+
+{{/* Service account name
+Usage:
+{{ include "thanos.serviceaccount.name" (dict "component" "bucketweb" "context" $) }}
+*/}}
+{{- define "thanos.serviceaccount.name" -}}
+{{- $name := printf "%s-%s" (include "common.names.fullname" .context) .component -}}
+
+{{- if .context.Values.existingServiceAccount -}}
+    {{- $name = .context.Values.existingServiceAccount -}}
+{{- end -}}
+
+{{- $component := index .context.Values .component -}}
+{{- if $component.serviceAccount.existingServiceAccount -}}
+    {{- $name = $component.serviceAccount.existingServiceAccount -}}
+{{- end -}}
+
+{{- printf "%s" $name -}}
+{{- end -}}
+
+{{/* Service account use existing
+{{- include "thanos.serviceaccount.use-existing" (dict "component" "bucketweb" "context" $) -}}
+*/}}
+{{- define "thanos.serviceaccount.use-existing" -}}
+{{- $component := index .context.Values .component -}}
+{{- if .context.Values.existingServiceAccount -}}
+    {{- true -}}
+{{- else if $component.serviceAccount.existingServiceAccount -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/thanos/templates/bucketweb/deployment.yaml
+++ b/thanos/templates/bucketweb/deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.bucketweb.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}-bucketweb
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+spec:
+  replicas: {{ .Values.bucketweb.replicaCount }}
+  strategy:
+    type: {{ .Values.bucketweb.strategyType }}
+    {{- if (eq "Recreate" .Values.bucketweb.strategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bucketweb
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: bucketweb
+      annotations:
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
+        {{- if .Values.bucketweb.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+{{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "bucketweb" "context" $) }}
+      {{- if .Values.bucketweb.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.bucketweb.podAffinityPreset "component" "bucketweb" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.bucketweb.podAntiAffinityPreset "component" "bucketweb" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.bucketweb.nodeAffinityPreset.type "key" .Values.bucketweb.nodeAffinityPreset.key "values" .Values.bucketweb.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.bucketweb.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.bucketweb.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.bucketweb.priorityClassName }}
+      priorityClassName: {{ .Values.bucketweb.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.bucketweb.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.bucketweb.securityContext.runAsUser }}
+        fsGroup: {{ .Values.bucketweb.securityContext.fsGroup }}
+      {{- end }}
+      containers:
+        - name: bucketweb
+          image: {{ include "thanos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          args:
+            - tools
+            - bucket
+            - web
+            - --http-address=0.0.0.0:8080
+            - --log.level={{ .Values.bucketweb.logLevel }}
+            - --objstore.config-file=/conf/objstore.yml
+            {{- if .Values.bucketweb.refresh }}
+            - --refresh={{ .Values.bucketweb.refresh }}
+            {{- end }}
+            {{- if .Values.bucketweb.timeout }}
+            - --timeout={{ .Values.bucketweb.timeout }}
+            {{- end }}
+            {{- if .Values.bucketweb.extraFlags }}
+            {{- .Values.bucketweb.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- if .Values.bucketweb.livenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.livenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.bucketweb.readinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.readinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.bucketweb.resources }}
+          resources: {{- toYaml .Values.bucketweb.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: objstore-config
+              mountPath: /conf
+      volumes:
+        - name: objstore-config
+          secret:
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- end }}
+{{- end }}

--- a/thanos/templates/bucketweb/ingress.yaml
+++ b/thanos/templates/bucketweb/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.bucketweb.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}-bucketweb
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- if .Values.bucketweb.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.bucketweb.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.bucketweb.ingress.hostname }}
+    - host: {{ .Values.bucketweb.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.bucketweb.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.bucketweb.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "bucketweb") "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.bucketweb.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "bucketweb") "servicePort" "http" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.bucketweb.ingress.tls .Values.bucketweb.ingress.extraTls .Values.bucketweb.ingress.hosts }}
+  tls:
+    {{- if or .Values.bucketweb.ingress.secrets .Values.bucketweb.ingress.tls }}
+    - hosts:
+        - {{ .Values.bucketweb.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.bucketweb.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.bucketweb.ingress.extraTls }}
+    {{- toYaml .Values.bucketweb.ingress.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/bucketweb/pdb.yaml
+++ b/thanos/templates/bucketweb/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.bucketweb.enabled .Values.bucketweb.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}-bucketweb
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+spec:
+  {{- if .Values.bucketweb.pdb.minAvailable }}
+  minAvailable: {{ .Values.bucketweb.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.bucketweb.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.bucketweb.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bucketweb
+{{- end }}

--- a/thanos/templates/bucketweb/service.yaml
+++ b/thanos/templates/bucketweb/service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.bucketweb.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-bucketweb
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+  {{- if .Values.bucketweb.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.bucketweb.service.type }}
+  {{- if and .Values.bucketweb.service.clusterIP (eq .Values.bucketweb.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.bucketweb.service.clusterIP }}
+  {{- end }}
+  {{- if and .Values.bucketweb.service.loadBalancerIP (eq .Values.bucketweb.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.bucketweb.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.bucketweb.service.type "LoadBalancer") .Values.bucketweb.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.bucketweb.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.bucketweb.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if (and (or (eq .Values.bucketweb.service.type "NodePort") (eq .Values.bucketweb.service.type "LoadBalancer")) .Values.bucketweb.service.http.nodePort) }}
+      {{- else if eq .Values.bucketweb.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    {{- if .Values.bucketweb.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+    {{- end }}
+{{- end }}

--- a/thanos/templates/bucketweb/serviceaccount.yaml
+++ b/thanos/templates/bucketweb/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.bucketweb.enabled (not (include "thanos.serviceaccount.use-existing" (dict "component" "bucketweb" "context" $))) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "bucketweb" "context" $) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+  {{- if .Values.bucketweb.serviceAccount.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.bucketweb.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/thanos/templates/bucketweb/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.bucketweb.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-bucketweb
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bucketweb
+  endpoints:
+    - port: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/thanos/templates/bucketweb/tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.bucketweb.ingress.enabled }}
+{{- range .Values.bucketweb.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-bucketweb
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/thanos/templates/compactor/deployment.yaml
+++ b/thanos/templates/compactor/deployment.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.compactor.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}-compactor
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+spec:
+  replicas: 1
+  strategy:
+    type: {{ .Values.compactor.strategyType }}
+    {{- if (eq "Recreate" .Values.compactor.strategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: compactor
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: compactor
+      annotations:
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
+        {{- if .Values.compactor.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.compactor.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+{{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "compactor" "context" $) }}
+      {{- if .Values.compactor.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.compactor.podAffinityPreset "component" "compactor" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.compactor.podAntiAffinityPreset "component" "compactor" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.compactor.nodeAffinityPreset.type "key" .Values.compactor.nodeAffinityPreset.key "values" .Values.compactor.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.compactor.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.compactor.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.compactor.priorityClassName }}
+      priorityClassName: {{ .Values.compactor.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.compactor.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.compactor.securityContext.fsGroup }}
+      {{- end }}
+      {{- if and .Values.volumePermissions.enabled .Values.compactor.persistence.enabled }}
+      initContainers:
+        - name: init-chmod-data
+          image: {{ include "thanos.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /data
+              chown -R "{{ .Values.compactor.securityContext.runAsUser }}:{{ .Values.compactor.securityContext.fsGroup }}" /data
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- end }}
+      containers:
+        - name: compactor
+          image: {{ include "thanos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.compactor.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.compactor.securityContext.runAsUser }}
+          {{- end }}
+          args:
+            - compact
+            - --log.level={{ .Values.compactor.logLevel }}
+            - --http-address=0.0.0.0:10902
+            - --data-dir=/data
+            - --retention.resolution-raw={{ .Values.compactor.retentionResolutionRaw }}
+            - --retention.resolution-5m={{ .Values.compactor.retentionResolution5m }}
+            - --retention.resolution-1h={{ .Values.compactor.retentionResolution1h }}
+            - --consistency-delay={{ .Values.compactor.consistencyDelay }}
+            - --objstore.config-file=/conf/objstore.yml
+            {{- if .Values.compactor.extraFlags }}
+            {{- .Values.compactor.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
+            - --wait
+          ports:
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+          {{- if .Values.compactor.livenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.livenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.compactor.readinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.readinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.compactor.resources }}
+          resources: {{- toYaml .Values.compactor.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: objstore-config
+              mountPath: /conf
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: objstore-config
+          secret:
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- end }}
+        - name: data
+          {{- if .Values.compactor.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "thanos.compactor.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}

--- a/thanos/templates/compactor/pvc.yaml
+++ b/thanos/templates/compactor/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.compactor.persistence.enabled (not .Values.compactor.persistence.existingClaim) .Values.compactor.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "common.names.fullname" . }}-compactor
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+spec:
+  accessModes:
+  {{- range .Values.compactor.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.compactor.persistence.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.compactor.persistence "global" .Values.global) | nindent 2 }}
+{{- end }}

--- a/thanos/templates/compactor/service.yaml
+++ b/thanos/templates/compactor/service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.compactor.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-compactor
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+  {{- if .Values.compactor.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.compactor.service.type }}
+  {{- if and .Values.compactor.service.clusterIP (eq .Values.compactor.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.compactor.service.clusterIP }}
+  {{- end }}
+  {{- if and .Values.compactor.service.loadBalancerIP (eq .Values.compactor.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.compactor.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.compactor.service.type "LoadBalancer") .Values.compactor.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.compactor.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.compactor.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if (and (or (eq .Values.compactor.service.type "NodePort") (eq .Values.compactor.service.type "LoadBalancer")) .Values.compactor.service.http.nodePort) }}
+      {{- else if eq .Values.compactor.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    {{- if .Values.compactor.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.compactor.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+    {{- end }}
+{{- end }}

--- a/thanos/templates/compactor/serviceaccount.yaml
+++ b/thanos/templates/compactor/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.compactor.enabled (not (include "thanos.serviceaccount.use-existing" (dict "component" "compactor" "context" $))) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "compactor" "context" $) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+  {{- if .Values.compactor.serviceAccount.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.compactor.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/compactor/servicemonitor.yaml
+++ b/thanos/templates/compactor/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.compactor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-compactor
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: compactor
+  endpoints:
+    - port: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/thanos/templates/objstore-secret.yaml
+++ b/thanos/templates/objstore-secret.yaml
@@ -1,0 +1,18 @@
+{{- if (include "thanos.createObjstoreSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-objstore-secret
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+data:
+  objstore.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.objstoreConfig "context" $) | b64enc | nindent 4 }}
+{{- if .Values.indexCacheConfig }}
+  index-cache.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.indexCacheConfig "context" $) | b64enc | nindent 4 }}
+{{- end }}
+{{- if .Values.bucketCacheConfig }}
+  bucket-cache.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.bucketCacheConfig "context" $) | b64enc | nindent 4 }}
+{{- end }}
+{{ end }}

--- a/thanos/templates/query-frontend/configmap.yaml
+++ b/thanos/templates/query-frontend/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if (include "thanos.queryFrontend.createConfigmap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend-configmap
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+data:
+  config.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.config "context" $) | nindent 4 }}
+{{ end }}

--- a/thanos/templates/query-frontend/deployment.yaml
+++ b/thanos/templates/query-frontend/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if .Values.queryFrontend.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+spec:
+  replicas: {{ .Values.queryFrontend.replicaCount }}
+  strategy:
+    type: {{ .Values.queryFrontend.strategyType }}
+    {{- if (eq "Recreate" .Values.queryFrontend.strategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query-frontend
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: query-frontend
+      {{- if or .Values.queryFrontend.podAnnotations (include "thanos.queryFrontend.createConfigmap" .) }}
+      annotations:
+        {{- if (include "thanos.queryFrontend.createConfigmap" .) }}
+        checksum/query-frontend-configuration: {{ include (print $.Template.BasePath "/query-frontend/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.queryFrontend.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "query-frontend" "context" $) }}
+      {{- if .Values.queryFrontend.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.queryFrontend.podAffinityPreset "component" "query-frontend" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.queryFrontend.podAntiAffinityPreset "component" "query-frontend" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.queryFrontend.nodeAffinityPreset.type "key" .Values.queryFrontend.nodeAffinityPreset.key "values" .Values.queryFrontend.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.queryFrontend.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.queryFrontend.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.queryFrontend.priorityClassName }}
+      priorityClassName: {{ .Values.queryFrontend.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.queryFrontend.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.queryFrontend.securityContext.runAsUser }}
+        fsGroup: {{ .Values.queryFrontend.securityContext.fsGroup }}
+      {{- end }}
+      containers:
+        - name: query-frontend
+          image: {{ include "thanos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          args:
+            - query-frontend
+            - --log.level={{ .Values.queryFrontend.logLevel }}
+            - --http-address=0.0.0.0:10902
+            - --query-frontend.downstream-url=http://{{ include "common.names.fullname" . }}-query:{{ $query.service.http.port }}
+            {{- if or .Values.queryFrontend.config .Values.queryFrontend.existingConfigmap }}
+            - --query-range.response-cache-config-file=/conf/cache/config.yml
+            {{- end }}
+            {{- if .Values.queryFrontend.extraFlags }}
+            {{- .Values.queryFrontend.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+          {{- if .Values.queryFrontend.livenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.livenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.queryFrontend.readinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.readinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.queryFrontend.resources }}
+          resources: {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if or .Values.queryFrontend.config .Values.queryFrontend.existingConfigmap }}
+            - name: cache-config
+              mountPath: /conf/cache
+            {{- end }}
+      volumes:
+        {{- if or .Values.queryFrontend.config .Values.queryFrontend.existingConfigmap }}
+        - name: cache-config
+          configMap:
+            name: {{ include "thanos.queryFrontend.configmapName" . }}
+        {{- end }}
+{{- end }}

--- a/thanos/templates/query-frontend/hpa.yaml
+++ b/thanos/templates/query-frontend/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}-query-frontend
+  minReplicas: {{ .Values.queryFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.queryFrontend.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.queryFrontend.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if .Values.queryFrontend.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
+    {{- end }}
+{{- end }}

--- a/thanos/templates/query-frontend/ingress.yaml
+++ b/thanos/templates/query-frontend/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.queryFrontend.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- if .Values.queryFrontend.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.queryFrontend.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.queryFrontend.ingress.hostname }}
+    - host: {{ .Values.queryFrontend.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.queryFrontend.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.queryFrontend.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query-frontend") "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.queryFrontend.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query-frontend") "servicePort" "http" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.queryFrontend.ingress.tls .Values.queryFrontend.ingress.extraTls .Values.queryFrontend.ingress.hosts }}
+  tls:
+    {{- if .Values.queryFrontend.ingress.secrets }}
+    - hosts:
+        - {{ .Values.queryFrontend.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.queryFrontend.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.queryFrontend.ingress.extraTls }}
+    {{- toYaml .Values.queryFrontend.ingress.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/query-frontend/pdb.yaml
+++ b/thanos/templates/query-frontend/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+spec:
+  {{- if .Values.queryFrontend.pdb.minAvailable }}
+  minAvailable: {{ .Values.queryFrontend.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.queryFrontend.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.queryFrontend.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query-frontend
+{{- end }}

--- a/thanos/templates/query-frontend/psp-clusterrole.yaml
+++ b/thanos/templates/query-frontend/psp-clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pspEnabled .Values.queryFrontend.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "common.names.fullname" . }}-query-frontend
+{{- end -}}

--- a/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pspEnabled .Values.queryFrontend.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+roleRef:
+  kind: ClusterRole
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "query-frontend" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/thanos/templates/query-frontend/psp.yaml
+++ b/thanos/templates/query-frontend/psp.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pspEnabled .Values.queryFrontend.rbac.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    ranges:
+    - max: 1001
+      min: 1001
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+{{- end -}}

--- a/thanos/templates/query-frontend/service.yaml
+++ b/thanos/templates/query-frontend/service.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.queryFrontend.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+  {{- if .Values.queryFrontend.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.queryFrontend.service.type }}
+  {{- if and .Values.queryFrontend.service.clusterIP (eq .Values.queryFrontend.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.queryFrontend.service.clusterIP }}
+  {{- end }}
+  {{- if and .Values.queryFrontend.service.loadBalancerIP (eq .Values.queryFrontend.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.queryFrontend.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.queryFrontend.service.type "LoadBalancer") .Values.queryFrontend.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.queryFrontend.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.queryFrontend.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if (and (or (eq .Values.queryFrontend.service.type "NodePort") (eq .Values.queryFrontend.service.type "LoadBalancer")) .Values.queryFrontend.service.http.nodePort) }}
+      nodePort: {{ .Values.queryFrontend.service.http.nodePort }}
+      {{- else if eq .Values.queryFrontend.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    {{- if .Values.queryFrontend.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+    {{- end }}
+{{- end }}

--- a/thanos/templates/query-frontend/serviceaccount.yaml
+++ b/thanos/templates/query-frontend/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.queryFrontend.enabled (not (include "thanos.serviceaccount.use-existing" (dict "component" "query-frontend" "context" $))) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "query-frontend" "context" $) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+  {{- if .Values.queryFrontend.serviceAccount.annotations }}
+  annotations:
+    {{ include "common.tplvalues.render" ( dict "value" .Values.queryFrontend.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/thanos/templates/query-frontend/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.queryFrontend.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query-frontend
+  endpoints:
+    - port: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/thanos/templates/query-frontend/tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.queryFrontend.ingress.enabled }}
+{{- range .Values.queryFrontend.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/thanos/templates/query/deployment.yaml
+++ b/thanos/templates/query/deployment.yaml
@@ -1,0 +1,157 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+spec:
+  replicas: {{ $query.replicaCount }}
+  strategy:
+    type: {{ $query.strategyType }}
+    {{- if (eq "Recreate" $query.strategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: query
+      {{- if or (include "thanos.query.createSDConfigmap" .) $query.existingSDConfigmap $query.podAnnotations }}
+      annotations:
+        {{- if or (include "thanos.query.createSDConfigmap" .) $query.existingSDConfigmap }}
+        checksum/ruler-configuration: {{ include (print $.Template.BasePath "/query/sd-configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if $query.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" $query.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+{{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "query" "context" $) }}
+      {{- if $query.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" $query.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" $query.podAffinityPreset "component" "query" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $query.podAntiAffinityPreset "component" "query" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $query.nodeAffinityPreset.type "key" $query.nodeAffinityPreset.key "values" $query.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if $query.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $query.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if $query.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" $query.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if $query.priorityClassName }}
+      priorityClassName: {{ $query.priorityClassName | quote }}
+      {{- end }}
+      {{- if $query.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ $query.securityContext.runAsUser }}
+        fsGroup: {{ $query.securityContext.fsGroup }}
+      {{- end }}
+      containers:
+        - name: query
+          image: {{ include "thanos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          args:
+            - query
+            - --log.level={{ $query.logLevel }}
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            {{- if kindIs "string" $query.replicaLabel }}
+            - --query.replica-label={{ $query.replicaLabel }}
+            {{- else }}
+            {{- range $query.replicaLabel }}
+            - --query.replica-label={{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if or (include "thanos.query.createSDConfigmap" .) $query.existingSDConfigmap }}
+            - --store.sd-files=/conf/servicediscovery.yml
+            {{- end }}
+            {{- if and $query.dnsDiscovery.enabled $query.dnsDiscovery.sidecarsService $query.dnsDiscovery.sidecarsNamespace }}
+            - --store=dnssrv+_grpc._tcp.{{- include "common.tplvalues.render" ( dict "value" $query.dnsDiscovery.sidecarsService "context" $) -}}.{{- include "common.tplvalues.render"  ( dict "value" $query.dnsDiscovery.sidecarsNamespace "context" $) -}}.svc.{{ .Values.clusterDomain }}
+            {{- end }}
+            {{- if and .Values.storegateway.enabled $query.dnsDiscovery.enabled }}
+            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-storegateway.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            {{- end }}
+            {{- if and .Values.ruler.enabled $query.dnsDiscovery.enabled }}
+            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            {{- end }}
+            {{- range $query.stores }}
+            - --store={{ . }}
+            {{- end }}
+            {{- if $query.grpcTLS.server.secure }}
+            - --grpc-server-tls-cert=/tls/server/cert.pem
+            - --grpc-server-tls-key=/tls/server/key.pem
+            - --grpc-server-tls-client-ca=/tls/server/ca.pem
+            {{- end }}
+            {{- if $query.grpcTLS.client.secure }}
+            - --grpc-client-tls-secure
+            {{- if $query.grpcTLS.client.cert }}
+            - --grpc-client-tls-cert=/tls/client/cert.pem
+            {{- end }}
+            {{- if $query.grpcTLS.client.key }}
+            - --grpc-client-tls-key=/tls/client/key.pem
+            {{- end }}
+            {{- if $query.grpcTLS.client.ca }}
+            - --grpc-client-tls-ca=/tls/client/ca.pem
+            {{- end }}
+            {{- if $query.grpcTLS.client.servername }}
+            - --grpc-client-server-name={{$query.grpcTLS.client.servername}}
+            {{- end }}
+            {{- end }}
+            {{- if $query.extraFlags }}
+            {{- $query.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+            - name: grpc
+              containerPort: 10901
+              protocol: TCP
+          {{- if $query.livenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" $query.livenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if $query.readinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" $query.readinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if $query.resources }}
+          resources: {{- toYaml $query.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+      {{- if or (include "thanos.query.createSDConfigmap" .) $query.existingSDConfigmap }}
+            - name: sd-config
+              mountPath: /conf/servicediscovery.yml
+              subPath: servicediscovery.yml
+      {{- end }}
+      {{- if $query.grpcTLS.server.secure }}
+            - name: tls-server
+              mountPath: /tls/server
+      {{- end }}
+      {{- if $query.grpcTLS.client.secure }}
+            - name: tls-client
+              mountPath: /tls/client
+      {{- end }}
+      volumes:
+      {{- if or (include "thanos.query.createSDConfigmap" .) $query.existingSDConfigmap }}
+        - name: sd-config
+          configMap:
+            name: {{ include "thanos.query.SDConfigmapName" . }}
+      {{- end }}
+      {{- if $query.grpcTLS.server.secure }}
+        - name: tls-server
+          secret:
+            secretName: {{ include "common.names.fullname" . }}-query-tls-server
+      {{- end }}
+      {{- if $query.grpcTLS.client.secure }}
+        - name: tls-client
+          secret:
+            secretName: {{ include "common.names.fullname" . }}-query-tls-client
+      {{- end }}
+{{- end }}

--- a/thanos/templates/query/hpa.yaml
+++ b/thanos/templates/query/hpa.yaml
@@ -1,0 +1,29 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled $query.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}-query
+  minReplicas: {{ $query.autoscaling.minReplicas }}
+  maxReplicas: {{ $query.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $query.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ $query.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if $query.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ $query.autoscaling.targetCPU }}
+    {{- end }}
+{{- end }}    

--- a/thanos/templates/query/ingress-grpc.yaml
+++ b/thanos/templates/query/ingress-grpc.yaml
@@ -1,0 +1,48 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.ingress.grpc.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}-grpc
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- if $query.ingress.grpc.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := $query.ingress.grpc.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if $query.ingress.grpc.hostname }}
+    - host: {{ $query.ingress.grpc.hostname }}
+      http:
+        paths:
+          - path: {{ $query.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ $query.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" (include "common.names.fullname" .) "query") "servicePort" "grpc" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range $query.ingress.grpc.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" (include "common.names.fullname" .) "query") "servicePort" "grpc" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or $query.ingress.grpc.tls $query.ingress.grpc.extraTls $query.ingress.grpc.hosts }}
+  tls:
+    {{- if $query.ingress.grpc.tls }}
+    - hosts:
+        - {{ $query.ingress.grpc.hostname }}
+      secretName: {{ printf "%s-tls" $query.ingress.grpc.hostname }}
+    {{- end }}
+    {{- if $query.ingress.grpc.extraTls }}
+    {{- toYaml $query.ingress.grpc.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/query/ingress.yaml
+++ b/thanos/templates/query/ingress.yaml
@@ -1,0 +1,48 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- if $query.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := $query.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if $query.ingress.hostname }}
+    - host: {{ $query.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ $query.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ $query.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query") "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range $query.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query") "servicePort" "http" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or $query.ingress.tls $query.ingress.extraTls $query.ingress.hosts }}
+  tls:
+    {{- if or $query.ingress.secrets $query.ingress.tls }}
+    - hosts:
+        - {{ $query.ingress.hostname }}
+      secretName: {{ printf "%s-tls" $query.ingress.hostname }}
+    {{- end }}
+    {{- if $query.ingress.extraTls }}
+    {{- toYaml $query.ingress.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/query/pdb.yaml
+++ b/thanos/templates/query/pdb.yaml
@@ -1,0 +1,19 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled $query.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+spec:
+  {{- if $query.pdb.minAvailable }}
+  minAvailable: {{ $query.pdb.minAvailable }}
+  {{- end }}
+  {{- if $query.pdb.maxUnavailable }}
+  maxUnavailable: {{ $query.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query
+{{- end }}

--- a/thanos/templates/query/psp-clusterrole.yaml
+++ b/thanos/templates/query/psp-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled $query.pspEnabled $query.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "common.names.fullname" . }}-query
+{{- end -}}

--- a/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled $query.pspEnabled $query.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+roleRef:
+  kind: ClusterRole
+  name: {{ include "common.names.fullname" . }}-query
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "query" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/thanos/templates/query/psp.yaml
+++ b/thanos/templates/query/psp.yaml
@@ -1,0 +1,23 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled $query.pspEnabled $query.rbac.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    ranges:
+    - max: 1001
+      min: 1001
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+{{- end -}}

--- a/thanos/templates/query/sd-configmap.yaml
+++ b/thanos/templates/query/sd-configmap.yaml
@@ -1,0 +1,12 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if (include "thanos.query.createSDConfigmap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-sd-configmap
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+data:
+  servicediscovery.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" $query.sdConfig "context" $) | nindent 4 }}
+{{ end }}

--- a/thanos/templates/query/service.yaml
+++ b/thanos/templates/query/service.yaml
@@ -1,0 +1,49 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+  {{- if $query.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" $query.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $query.service.type }}
+  {{- if and $query.service.clusterIP (eq $query.service.type "ClusterIP") }}
+  clusterIP: {{ $query.service.clusterIP }}
+  {{- end }}
+  {{- if and $query.service.loadBalancerIP (eq $query.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ $query.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq $query.service.type "LoadBalancer") $query.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml $query.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ $query.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if (and (or (eq $query.service.type "NodePort") (eq $query.service.type "LoadBalancer")) $query.service.http.nodePort) }}
+      nodePort: {{ $query.service.http.nodePort }}
+      {{- else if eq $query.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    - port: {{ $query.service.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+      {{- if (and (or (eq $query.service.type "NodePort") (eq $query.service.type "LoadBalancer")) $query.service.grpc.nodePort) }}
+      nodePort: {{ $query.service.grpc.nodePort }}
+      {{- else if eq $query.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: 
+    {{- if $query.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" $query.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: query
+    {{- end }}
+{{- end }}

--- a/thanos/templates/query/serviceaccount.yaml
+++ b/thanos/templates/query/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled (not (include "thanos.serviceaccount.use-existing" (dict "component" "query" "context" $))) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "query" "context" $) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+  {{- if $query.serviceAccount.annotations }}
+  annotations:
+    {{ include "common.tplvalues.render" ( dict "value" $query.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/query/servicemonitor.yaml
+++ b/thanos/templates/query/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if and $query.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query
+  endpoints:
+    - port: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/thanos/templates/query/tls-client-secret.yaml
+++ b/thanos/templates/query/tls-client-secret.yaml
@@ -1,0 +1,20 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.grpcTLS.client.secure -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-tls-client
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+type: Opaque
+data:
+{{- if $query.grpcTLS.client.cert }}
+  cert.pem: {{ $query.grpcTLS.client.cert | b64enc | quote }}
+{{- end }}
+{{- if $query.grpcTLS.client.key }}
+  key.pem: {{ $query.grpcTLS.client.key | b64enc | quote }}
+{{- end }}
+{{- if $query.grpcTLS.client.ca }}
+  ca.pem : {{ $query.grpcTLS.client.ca | b64enc | quote }}
+{{- end }}
+{{ end }}

--- a/thanos/templates/query/tls-secrets.yaml
+++ b/thanos/templates/query/tls-secrets.yaml
@@ -1,0 +1,15 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.ingress.enabled }}
+{{- range $query.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/thanos/templates/query/tls-server-secret.yaml
+++ b/thanos/templates/query/tls-server-secret.yaml
@@ -1,0 +1,14 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if $query.grpcTLS.server.secure -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-query-tls-server
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+type: Opaque
+data:
+  cert.pem: {{ $query.grpcTLS.server.cert | b64enc | quote }}
+  key.pem: {{ $query.grpcTLS.server.key | b64enc | quote }}
+  ca.pem : {{ $query.grpcTLS.server.ca | b64enc | quote }}
+{{ end }}

--- a/thanos/templates/ruler/configmap.yaml
+++ b/thanos/templates/ruler/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if (include "thanos.ruler.createConfigmap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler-configmap
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+data:
+  ruler.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.ruler.config "context" $) | nindent 4 }}
+{{ end }}

--- a/thanos/templates/ruler/pdb.yaml
+++ b/thanos/templates/ruler/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.ruler.enabled .Values.ruler.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+spec:
+  {{- if .Values.ruler.pdb.minAvailable }}
+  minAvailable: {{ .Values.ruler.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.ruler.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.ruler.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ruler
+{{- end }}

--- a/thanos/templates/ruler/service-headless.yaml
+++ b/thanos/templates/ruler/service-headless.yaml
@@ -1,0 +1,22 @@
+{{- if and (.Values.ruler.enabled) (.Values.ruler.service.additionalHeadless) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler-headless
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.ruler.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.ruler.service.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: rcp
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+{{- end }}

--- a/thanos/templates/ruler/service.yaml
+++ b/thanos/templates/ruler/service.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.ruler.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+    {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+    prometheus-operator/monitor: 'true'
+    {{- end }}
+  {{- if .Values.ruler.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.ruler.service.type }}
+  {{- if and .Values.ruler.service.clusterIP (eq .Values.ruler.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.ruler.service.clusterIP }}
+  {{- end }}
+  {{- if and .Values.ruler.service.loadBalancerIP (eq .Values.ruler.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.ruler.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.ruler.service.type "LoadBalancer") .Values.ruler.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.ruler.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.ruler.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if (and (or (eq .Values.ruler.service.type "NodePort") (eq .Values.ruler.service.type "LoadBalancer")) .Values.ruler.service.http.nodePort) }}
+      nodePort: {{ .Values.ruler.service.http.nodePort }}
+      {{- else if eq .Values.ruler.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    - port: {{ .Values.ruler.service.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+      {{- if (and (or (eq .Values.ruler.service.type "NodePort") (eq .Values.ruler.service.type "LoadBalancer")) .Values.ruler.service.grpc.nodePort) }}
+      nodePort: {{ .Values.ruler.service.grpc.nodePort }}
+      {{- else if eq .Values.ruler.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    {{- if .Values.ruler.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ruler.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+    {{- end }}
+{{- end }}

--- a/thanos/templates/ruler/serviceaccount.yaml
+++ b/thanos/templates/ruler/serviceaccount.yaml
@@ -1,0 +1,13 @@
+
+{{- if and .Values.ruler.enabled (not (include "thanos.serviceaccount.use-existing" (dict "component" "ruler" "context" $))) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "ruler" "context" $) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+  {{- if .Values.ruler.serviceAccount.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ruler.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/ruler/servicemonitor.yaml
+++ b/thanos/templates/ruler/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.ruler.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ruler
+      prometheus-operator/monitor: 'true'
+  endpoints:
+    - port: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/thanos/templates/ruler/statefulset.yaml
+++ b/thanos/templates/ruler/statefulset.yaml
@@ -1,0 +1,163 @@
+{{- $query := (include "thanos.query.values" . | fromYaml) -}}
+{{- if .Values.ruler.enabled }}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+spec:
+  replicas: {{ .Values.ruler.replicaCount }}
+  podManagementPolicy: {{ .Values.ruler.podManagementPolicy }}
+  serviceName: {{ include "common.names.fullname" . }}-ruler-headless
+  updateStrategy:
+    type: {{ .Values.ruler.updateStrategyType }}
+    {{- if (eq "OnDelete" .Values.ruler.updateStrategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ruler
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: ruler
+      annotations:
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
+        checksum/ruler-configuration: {{ include (print $.Template.BasePath "/ruler/configmap.yaml") . | sha256sum }}
+        {{- if .Values.ruler.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.ruler.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+{{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "ruler" "context" $) }}
+      {{- if .Values.ruler.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.ruler.podAffinityPreset "component" "ruler" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.ruler.podAntiAffinityPreset "component" "ruler" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.ruler.nodeAffinityPreset.type "key" .Values.ruler.nodeAffinityPreset.key "values" .Values.ruler.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.ruler.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.ruler.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.ruler.priorityClassName }}
+      priorityClassName: {{ .Values.ruler.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.ruler.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.ruler.securityContext.fsGroup }}
+      {{- end }}
+      {{- if and .Values.volumePermissions.enabled .Values.ruler.persistence.enabled }}
+      initContainers:
+        - name: init-chmod-data
+          image: {{ include "thanos.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /data
+              chown -R "{{ .Values.ruler.securityContext.runAsUser }}:{{ .Values.ruler.securityContext.fsGroup }}" /data
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- end }}
+      containers:
+        - name: ruler
+          image: {{ include "thanos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.ruler.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.ruler.securityContext.runAsUser }}
+          {{- end }}
+          args:
+            - rule
+            - --log.level={{ .Values.ruler.logLevel }}
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --data-dir=/data
+            - --eval-interval={{ .Values.ruler.evalInterval }}
+            {{- range .Values.ruler.alertmanagers }}
+            - --alertmanagers.url={{ . }}
+            {{- end }}
+            {{- if and $query.enabled .Values.ruler.dnsDiscovery.enabled }}
+            - --query=dnssrv+_http._tcp.{{ include "common.names.fullname" . }}-query.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            {{- end }}
+            - --label=replica="$(POD_NAME)"
+            - --label=ruler_cluster="{{ .Values.ruler.clusterName }}"
+            - --alert.label-drop=replica
+            - --objstore.config-file=/conf/objstore/objstore.yml
+            - --rule-file=/conf/rules/ruler.yml
+            {{- range .Values.ruler.queries }}
+            - --query={{ . }}
+            {{- end }}
+            {{- if .Values.ruler.extraFlags }}
+            {{- .Values.ruler.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+            - name: grpc
+              containerPort: 10901
+              protocol: TCP
+          {{- if .Values.ruler.livenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.livenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ruler.readinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.readinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ruler.resources }}
+          resources: {{- toYaml .Values.ruler.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: ruler-config
+              mountPath: /conf/rules
+            - name: objstore-config
+              mountPath: /conf/objstore
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: ruler-config
+          configMap:
+            name: {{ include "thanos.ruler.configmapName" . }}
+        - name: objstore-config
+          secret:
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- end }}
+  {{- if and .Values.ruler.persistence.enabled .Values.ruler.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.ruler.persistence.existingClaim }}
+  {{- else if not .Values.ruler.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else if and .Values.ruler.persistence.enabled (not .Values.ruler.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+        {{- range .Values.ruler.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.ruler.persistence.size | quote }}
+        {{- include "common.storage.class" (dict "persistence" .Values.ruler.persistence "global" .Values.global) | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/storegateway/configmap.yaml
+++ b/thanos/templates/storegateway/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if (include "thanos.storegateway.createConfigmap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway-configmap
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+data:
+  config.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.config "context" $) | nindent 4 }}
+{{ end }}

--- a/thanos/templates/storegateway/hpa.yaml
+++ b/thanos/templates/storegateway/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.storegateway.enabled .Values.storegateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "common.names.fullname" . }}-storegateway
+  minReplicas: {{ .Values.storegateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.storegateway.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.storegateway.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if .Values.storegateway.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
+    {{- end }}
+{{- end }}

--- a/thanos/templates/storegateway/pdb.yaml
+++ b/thanos/templates/storegateway/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.storegateway.enabled .Values.storegateway.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+spec:
+  {{- if .Values.storegateway.pdb.minAvailable }}
+  minAvailable: {{ .Values.storegateway.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.storegateway.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.storegateway.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: storegateway
+{{- end }}

--- a/thanos/templates/storegateway/service-headless.yaml
+++ b/thanos/templates/storegateway/service-headless.yaml
@@ -1,0 +1,22 @@
+{{- if and (.Values.storegateway.enabled) (.Values.storegateway.service.additionalHeadless) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway-headless
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.storegateway.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.storegateway.service.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: rcp
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+{{- end }}

--- a/thanos/templates/storegateway/service.yaml
+++ b/thanos/templates/storegateway/service.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.storegateway.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+    {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+    prometheus-operator/monitor: 'true'
+    {{- end }}
+  {{- if .Values.storegateway.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.storegateway.service.type }}
+  {{- if and .Values.storegateway.service.clusterIP (eq .Values.storegateway.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.storegateway.service.clusterIP }}
+  {{- end }}
+  {{- if and .Values.storegateway.service.loadBalancerIP (eq .Values.storegateway.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.storegateway.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.storegateway.service.type "LoadBalancer") .Values.storegateway.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.storegateway.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.storegateway.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if (and (or (eq .Values.storegateway.service.type "NodePort") (eq .Values.storegateway.service.type "LoadBalancer")) .Values.storegateway.service.http.nodePort) }}
+      nodePort: {{ .Values.storegateway.service.http.nodePort }}
+      {{- else if eq .Values.storegateway.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    - port: {{ .Values.storegateway.service.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+      {{- if (and (or (eq .Values.storegateway.service.type "NodePort") (eq .Values.storegateway.service.type "LoadBalancer")) .Values.storegateway.service.grpc.nodePort) }}
+      nodePort: {{ .Values.storegateway.service.grpc.nodePort }}
+      {{- else if eq .Values.storegateway.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    {{- if .Values.storegateway.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+    {{- end }}
+{{- end }}

--- a/thanos/templates/storegateway/serviceaccount.yaml
+++ b/thanos/templates/storegateway/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.storegateway.enabled (not (include "thanos.serviceaccount.use-existing" (dict "component" "storegateway" "context" $))) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thanos.serviceaccount.name" (dict "component" "storegateway" "context" $) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+  {{- if .Values.storegateway.serviceAccount.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.storegateway.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/thanos/templates/storegateway/servicemonitor.yaml
+++ b/thanos/templates/storegateway/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.storegateway.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: storegateway
+      prometheus-operator/monitor: 'true'
+  endpoints:
+    - port: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/thanos/templates/storegateway/statefulset.yaml
+++ b/thanos/templates/storegateway/statefulset.yaml
@@ -1,0 +1,158 @@
+{{- if .Values.storegateway.enabled }}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ include "common.names.fullname" . }}-storegateway
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+spec:
+  replicas: {{ .Values.storegateway.replicaCount }}
+  podManagementPolicy: {{ .Values.storegateway.podManagementPolicy }}
+  serviceName: {{ include "common.names.fullname" . }}-storegateway-headless
+  updateStrategy:
+    type: {{ .Values.storegateway.updateStrategyType }}
+    {{- if (eq "OnDelete" .Values.storegateway.updateStrategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: storegateway
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: storegateway
+      annotations:
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
+        {{- if (include "thanos.storegateway.createConfigmap" .) }}
+        checksum/storegateway-configuration: {{ include (print $.Template.BasePath "/storegateway/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.storegateway.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+{{- include "thanos.imagePullSecrets" . | nindent 6 }}
+      serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "storegateway" "context" $) }}
+      {{- if .Values.storegateway.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.storegateway.podAffinityPreset "component" "storegateway" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.storegateway.podAntiAffinityPreset "component" "storegateway" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.storegateway.nodeAffinityPreset.type "key" .Values.storegateway.nodeAffinityPreset.key "values" .Values.storegateway.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.storegateway.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.storegateway.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.storegateway.priorityClassName }}
+      priorityClassName: {{ .Values.storegateway.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.storegateway.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.storegateway.securityContext.fsGroup }}
+      {{- end }}
+      {{- if and .Values.volumePermissions.enabled .Values.storegateway.persistence.enabled }}
+      initContainers:
+        - name: init-chmod-data
+          image: {{ include "thanos.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /data
+              chown -R "{{ .Values.storegateway.securityContext.runAsUser }}:{{ .Values.storegateway.securityContext.fsGroup }}" /data
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- end }}
+      containers:
+        - name: storegateway
+          image: {{ include "thanos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.storegateway.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.storegateway.securityContext.runAsUser }}
+          {{- end }}
+          args:
+            - store
+            - --log.level={{ .Values.storegateway.logLevel }}
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --data-dir=/data
+            - --objstore.config-file=/conf/objstore.yml
+            {{- if .Values.indexCacheConfig }}
+            - --index-cache.config-file=/conf/index-cache.yml
+            {{- end }}
+            {{- if .Values.bucketCacheConfig }}
+            - --store.caching-bucket.config-file=/conf/bucket-cache.yml
+            {{- end }}
+            {{- if or .Values.storegateway.config .Values.storegateway.existingConfigmap }}
+            - --index-cache.config-file=/conf/cache/config.yml
+            {{- end }}
+            {{- if .Values.storegateway.extraFlags }}
+            {{- .Values.storegateway.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+            - name: grpc
+              containerPort: 10901
+              protocol: TCP
+          {{- if .Values.storegateway.livenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.livenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.storegateway.readinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.readinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.storegateway.resources }}
+          resources: {{- toYaml .Values.storegateway.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: objstore-config
+              mountPath: /conf
+            - name: data
+              mountPath: /data
+            {{- if or .Values.storegateway.config .Values.storegateway.existingConfigmap }}
+            - name: cache-config
+              mountPath: /conf/cache
+            {{- end }}
+      volumes:
+        - name: objstore-config
+          secret:
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- end }}
+        {{- if or .Values.storegateway.config .Values.storegateway.existingConfigmap }}
+        - name: cache-config
+          configMap:
+            name: {{ include "thanos.storegateway.configmapName" . }}
+        {{- end }}
+  {{- if and .Values.storegateway.persistence.enabled .Values.storegateway.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.storegateway.persistence.existingClaim }}
+  {{- else if not .Values.storegateway.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else if and .Values.storegateway.persistence.enabled (not .Values.storegateway.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+        {{- range .Values.storegateway.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.storegateway.persistence.size | quote }}
+        {{- include "common.storage.class" (dict "persistence" .Values.storegateway.persistence "global" .Values.global) | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/thanos/values-production.yaml
+++ b/thanos/values-production.yaml
@@ -1,0 +1,1709 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
+## Bitnami Thanos image
+## ref: https://hub.docker.com/r/bitnami/thanos/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/thanos
+  tag: 0.17.2-scratch-r1
+  ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override common.names.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override common.names.fullname template
+##
+# fullnameOverride:
+
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Objstore Configuration
+## Specify content for objstore.yml
+##
+# objstoreConfig:
+
+## Secret with Objstore Configuration
+## Note: This will override objstoreConfig
+##
+# existingObjstoreSecret:
+##  optional item list for specifying a custom Secret key. If so, path should be objstore.yml
+# existingObjstoreSecretItems: []
+
+## Provide a common service account to be shared with all components
+##
+# existingServiceAccount: my-service-account
+
+## Thanos Query parameters
+##
+query:
+  ## Set to true to enable Thanos Query component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for query
+    ##
+    # existingServiceAccount: query-service-account
+
+  ## Labels to treat as a replica indicator along which data is deduplicated
+  ##
+  replicaLabel: [replica]
+
+  ## Dynamically configure store APIs using DNS discovery
+  ##
+  dnsDiscovery:
+    enabled: true
+    ## Sidecars service name to discover them using DNS discovery
+    ## Evaluated as a template.
+    # sidecarsService: "{{ .Release.Name }}-prometheus-thanos"
+    ##
+    ## Sidecars namespace to discover them using DNS discovery
+    ## Evaluated as a template.
+    # sidecarsNamespace: "{{ .Release.Namespace }}"
+
+  ## Statically configure store APIs to connect with Thanos Query
+  ##
+  stores: []
+
+  ## Query Service Discovery Configuration
+  ## Specify content for servicediscovery.yml
+  ##
+  # sdConfig:
+
+  ## ConfigMap with Query Service Discovery Configuration
+  ## NOTE: This will override query.sdConfig
+  ##
+  # existingSDConfigmap:
+
+  ## Extra Flags to passed to Thanos Query
+  ##
+  extraFlags: []
+
+  ## Number of Thanos Query replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Query pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Query pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Query node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Query pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: query.podAffinityPreset, query.podAntiAffinityPreset, and query.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Query pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Query pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for query pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Query pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  # Create ClusterRole and ClusterRolebing for the Service account
+  rbac:
+    create: false
+
+  # Create PodSecurity Policy
+  psp:
+    create: false
+
+  ## Thanos Query containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Query pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Thanos Query GRPC TLS parameters
+  ## to configure --grpc-server-tls-cert, --grpc-server-tls-key, --grpc-server-tls-client-ca, --grpc-client-tls-secure, --grpc-client-tls-cert, --grpc-client-tls-key, --grpc-client-tls-ca, --grpc-client-server-name
+  ## ref: https://github.com/thanos-io/thanos/blob/master/docs/components/query.md#flags
+  grpcTLS:
+    # TLS server side
+    server:
+      # Enable TLS for GRPC server
+      secure: false
+      # TLS Certificate for gRPC server, leave blank to disable TLS
+      cert:
+      # TLS Key for the gRPC server, leave blank to disable TLS
+      key:
+      # TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)
+      ca:
+    # TLS client side
+    client:
+      # Use TLS when talking to the gRPC server
+      secure: false
+      # TLS Certificates to use to identify this client to the server
+      cert:
+      # TLS Key for the client's certificate
+      key:
+      # TLS CA Certificates to use to verify gRPC servers
+      ca:
+      # Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
+      servername:
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Query service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: false
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPU: 50
+    #  targetMemory: 50
+
+  ## Query Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Query
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+
+    ## When specifying cert-manager.io/cluster-issuer: nameOfClusterIssuer annotation, enable tls for ingress
+    ##
+    tls: false
+
+    secrets: []
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
+
+    ## Create an ingress object for the GRPC service. This requires an HTTP/2
+    ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
+    ## - ingress.kubernetes.io/protocol: h2c
+    ## - service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    ## - service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    ## For more information see https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/
+    ## and also the documentation for your ingress controller.
+    ##
+    ## The options that are accepted are identical to the HTTP one listed above
+    grpc:
+      enabled: false
+      certManager: false
+      hostname: thanos-grpc.local
+      annotations: {}
+
+      ## The list of additional hostnames to be covered with this ingress record.
+      ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+      # extraHosts:
+      # - name: thanos-grpc.local
+      #   path: /
+
+      ## The tls configuration for additional hostnames to be covered with this ingress record.
+      ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      # extraTls:
+      # - hosts:
+      #     - thanos-grpc.local
+      #   secretName: thanos-grpc.local-tls
+
+      ## If you're providing your own certificates, please use this to add the certificates as secrets
+      ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+      ## -----BEGIN RSA PRIVATE KEY-----
+      ##
+      ## name should line up with a tlsSecret set further up
+      ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+      ##
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ##
+      secrets: []
+      # - name: thanos-grpc.local-tls
+      #   key:
+      #   certificate:
+
+      ## Override API Version (automatically detected if not set)
+      ##
+      apiVersion:
+
+      ## Ingress Path
+      ##
+      path: /
+
+      ## Ingress Path type
+      ##
+      pathType: ImplementationSpecific
+
+## Thanos Query Frontend parameters
+##
+
+queryFrontend:
+  ## Set to true to enable Thanos Query Frontend component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for Query Frontend
+    ##
+    # existingServiceAccount: query-frontend-service-account
+
+  extraFlags: []
+
+  ## Thanos Query Frontend Cache Configuration
+  ## Specify content for config.yml
+  ##
+  # config:
+
+  ## ConfigMap with Thanos Query Frontend Cache Configuration
+  ## NOTE: This will override queryFrontend.config
+  ##
+  # existingConfigmap:
+
+  ## Number of Thanos Query Frontend replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Query Frontend pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Query Frontend pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Query Frontend node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Query Frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: queryFrontend.podAffinityPreset, queryFrontend.podAntiAffinityPreset, and queryFrontend.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Query Frontend pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Query Frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for query frontend pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Query Frontend pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  # Create ClusterRole and ClusterRolebing for the Service account
+  rbac:
+    create: false
+
+  # Create PodSecurity Policy
+  pspEnabled: false
+
+  ## Thanos Query Frontend containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Query Frontend pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Query Frontend service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ##
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: false
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPU: 50
+    #  targetMemory: 50
+
+  ## Query Frontend Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Query Frontend
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
+
+    ## Override API Version (automatically detected if not set)
+    ##
+    apiVersion:
+
+    ## Ingress Path
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
+## Thanos Bucket Web parameters
+##
+bucketweb:
+  ## Set to true to enable Thanos Bucket Web component
+  ##
+  enabled: false
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for bucketweb
+    ##
+    # existingServiceAccount: bucketweb-service-account
+
+  ## Refresh interval to download metadata from remote storage
+  ##
+  refresh: 30m
+
+  ## Timeout to download metadata from remote storage
+  ##
+  timeout: 5m
+
+  ## Extra Flags to passed to Bucket Web
+  ##
+  extraFlags: []
+
+  ## Number of Thanos Query replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Bucket Web pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Bucket Web pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Bucket Web node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Bucket Web pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: bucketweb.podAffinityPreset, bucketweb.podAntiAffinityPreset, and bucketweb.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Bucket Web pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Bucket Web pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for bucketweb pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Bucket Web pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Bucket Web containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Bucket Web pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Bucket Web service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 8080
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Bucket Web Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Bucketweb
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos-bucketweb.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos-bucketweb.local
+    #   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos-bucketweb.local
+    #   secretName: thanos-bucketweb.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+
+    ## When specifying cert-manager.io/cluster-issuer: nameOfClusterIssuer annotation, enable tls for ingress
+    ##
+    tls: false
+
+    secrets: []
+    # - name: thanos-bucketweb.local-tls
+    #   key:
+
+    ## Override API Version (automatically detected if not set)
+    ##
+    apiVersion:
+
+    ## Ingress Path
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
+## Thanos Compactor parameters
+##
+compactor:
+  ## Set to true to enable Thanos Compactor component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for compactor
+    ##
+    # existingServiceAccount: compactor-service-account
+
+  ## Resolution and Retention flags
+  ##
+  retentionResolutionRaw: 30d
+  retentionResolution5m: 30d
+  retentionResolution1h: 10y
+
+  ## Minimum age of fresh (non-compacted) blocks
+  ## before they are being processed
+  ##
+  consistencyDelay: 30m
+
+  ## Extra Flags to passed to Thanos Compactor
+  ##
+  extraFlags: []
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Compactor pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Compactor pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Compactor node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Compactor pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: compactor.podAffinityPreset, compactor.podAntiAffinityPreset, and compactor.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Compactor pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Compactor pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for compactor pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Compactor pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Compactor containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Compactor pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Compactor service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Persistence parameters
+  ##
+  persistence:
+    enabled: true
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    # existingClaim:
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## Persistent Volume Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## Persistent Volume Claim size
+    ##
+    size: 8Gi
+
+## Thanos Store Gateway parameters
+##
+storegateway:
+  ## Set to true to enable Thanos Store Gateway component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for storegateway
+    ##
+    # existingServiceAccount: storegateway-service-account
+
+  ## Extra Flags to passed to Thanos Store Gateway
+  ##
+  extraFlags: []
+
+  ## Store Gateway Cache Configuration
+  ## Specify content for config.yml
+  ##
+  # config:
+
+  ## ConfigMap with Store Gateway Cache  Configuration
+  ## NOTE: This will override storegateway.config
+  ##
+  # existingConfigmap:
+
+  ## Number of Thanos Store Gateway replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or OnDelete by default.
+  ##
+  updateStrategyType: RollingUpdate
+
+  ## Statefulset Pod management policy: OrderedReady (default) or Parallel.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: OrderedReady
+
+  ## Thanos Store Gateway pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Store Gateway pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Store Gateway node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Store Gateway pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: storegateway.podAffinityPreset, storegateway.podAntiAffinityPreset, and storegateway.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Store Gateway pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Store Gateway pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for storegateway pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Store Gateway pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Store Gateway containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Store Gateway pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Store Gateway service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+    ## Create additional Headless service
+    ##
+    additionalHeadless: false
+
+  ## Persistence parameters
+  ##
+  persistence:
+    enabled: true
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    # existingClaim:
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## Persistent Volume Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## Persistent Volume Claim size
+    ##
+    size: 8Gi
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: false
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPU: 50
+    #  targetMemory: 50
+
+  ## Store Gateway Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+## Thanos Ruler parameters
+##
+ruler:
+  ## Set to true to enable Thanos Ruler component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for ruler
+    ##
+    # existingServiceAccount: ruler-service-account
+
+  ## Dynamically configure Query APIs using DNS discovery
+  ##
+  dnsDiscovery:
+    enabled: true
+
+  ## Alermanager URLs array
+  ##
+  alertmanagers: []
+
+  ## The default evaluation interval to use
+  ##
+  evalInterval: 1m
+
+  ## Used to set the 'ruler_cluster' label
+  ##
+  # clusterName:
+
+  ## Extra Flags to passed to Thanos Ruler
+  ##
+  extraFlags: []
+
+  ## Ruler Configuration
+  ## Specify content for ruler.yml
+  ##
+  # config:
+
+  ## ConfigMap with Ruler Configuration
+  ## NOTE: This will override ruler.config
+  ##
+  # existingConfigmap:
+
+  ## Number of Thanos Ruler replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or OnDelete by default.
+  ##
+  updateStrategyType: RollingUpdate
+
+  ## Statefulset Pod management policy: OrderedReady (default) or Parallel.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: OrderedReady
+
+  ## Thanos Ruler pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Ruler pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Ruler node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Ruler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: ruler.podAffinityPreset, ruler.podAntiAffinityPreset, and ruler.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Ruler pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Ruler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for ruler pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Ruler pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Ruler containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Ruler pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Ruler service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+    ## Create additional Headless service
+    ##
+    additionalHeadless: false
+
+  ## Persistence parameters
+  ##
+  persistence:
+    enabled: true
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    # existingClaim:
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## Persistent Volume Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## Persistent Volume Claim size
+    ##
+    size: 8Gi
+
+  ## Ruler Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+## Prometheus metrics
+##
+metrics:
+  enabled: true
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: true
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+    ## Labels to add to the ServiceMonitor object
+    ##
+    # labels:
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+## Init Container parameters
+## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
+## values from the securityContext section of the component
+##
+volumePermissions:
+  enabled: false
+  ## Bitnami Minideb image
+  ## ref: https://hub.docker.com/r/bitnami/minideb/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+## MinIO(TM) Chart configuration
+##
+minio:
+  ## Set to true to deploy a MinIO(TM) chart
+  ## to be used as an objstore for Thanos
+  ##
+  enabled: false
+
+  ## MinIO(TM) credentials
+  ##
+  accessKey:
+    password: ''
+  secretKey:
+    password: ''
+
+  ## Default MinIO(TM) buckets
+  ##
+  defaultBuckets: 'thanos'

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,0 +1,1734 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
+## Bitnami Thanos image
+## ref: https://hub.docker.com/r/bitnami/thanos/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/thanos
+  tag: 0.17.2-scratch-r1
+  ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override common.names.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override common.names.fullname template
+##
+# fullnameOverride:
+
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Objstore Configuration
+## Specify content for objstore.yml
+##
+# objstoreConfig:
+
+## Index cache Configuration
+## Specify content for index-cache.yml
+##
+# indexCacheConfig:
+
+## Bucket cache Configuration
+## Specify content for bucket-cache.yml
+##
+# bucketCacheConfig:
+
+## Secret with Objstore Configuration
+## Note: This will override objstoreConfig
+##
+# existingObjstoreSecret:
+##  optional item list for specifying a custom Secret key. If so, path should be objstore.yml
+# existingObjstoreSecretItems: []
+
+## Provide a common service account to be shared with all components
+##
+# existingServiceAccount: my-service-account
+
+## Thanos Query parameters
+##
+query:
+  ## Set to true to enable Thanos Query component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for query
+    ##
+    # existingServiceAccount: query-service-account
+
+  ## Labels to treat as a replica indicator along which data is deduplicated
+  ##
+  replicaLabel: [replica]
+
+  ## Dynamically configure store APIs using DNS discovery
+  ##
+  dnsDiscovery:
+    enabled: true
+    ## Sidecars service name to discover them using DNS discovery
+    ## Evaluated as a template.
+    # sidecarsService: "{{ .Release.Name }}-prometheus-thanos"
+    ##
+    ## Sidecars namespace to discover them using DNS discovery
+    ## Evaluated as a template.
+    # sidecarsNamespace: "{{ .Release.Namespace }}"
+
+  ## Statically configure store APIs to connect with Thanos Query
+  ##
+  stores: []
+
+  ## Query Service Discovery Configuration
+  ## Specify content for servicediscovery.yml
+  ##
+  # sdConfig:
+
+  ## ConfigMap with Query Service Discovery Configuration
+  ## NOTE: This will override query.sdConfig
+  ##
+  # existingSDConfigmap:
+
+  ## Extra Flags to passed to Thanos Query
+  ##
+  extraFlags: []
+
+  ## Number of Thanos Query replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Query pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Query pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Query node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Query pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: query.podAffinityPreset, query.podAntiAffinityPreset, and query.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Query pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Query pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for query pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Query pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  # Create ClusterRole and ClusterRolebing for the Service account
+  rbac:
+    create: false
+
+  # Create PodSecurity Policy
+  pspEnabled: false
+
+  ## Thanos Query containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Query pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Thanos Query GRPC TLS parameters
+  ## to configure --grpc-server-tls-cert, --grpc-server-tls-key, --grpc-server-tls-client-ca, --grpc-client-tls-secure, --grpc-client-tls-cert, --grpc-client-tls-key, --grpc-client-tls-ca, --grpc-client-server-name
+  ## ref: https://github.com/thanos-io/thanos/blob/master/docs/components/query.md#flags
+  grpcTLS:
+    # TLS server side
+    server:
+      # enable TLS for GRPC server
+      secure: false
+      # TLS Certificate for gRPC server, leave blank to disable TLS
+      cert:
+      # TLS Key for the gRPC server, leave blank to disable TLS
+      key:
+      # TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)
+      ca:
+    # TLS client side
+    client:
+      # Use TLS when talking to the gRPC server
+      secure: false
+      # TLS Certificates to use to identify this client to the server
+      cert:
+      # TLS Key for the client's certificate
+      key:
+      # TLS CA Certificates to use to verify gRPC servers
+      ca:
+      # Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
+      servername:
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Query service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: false
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPU: 50
+    #  targetMemory: 50
+
+  ## Query Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Query
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
+    #   pathType: ImplementationSpecific
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+
+    ## When specifying cert-manager.io/cluster-issuer: nameOfClusterIssuer annotation, enable tls for ingress
+    ##
+    tls: false
+
+    secrets: []
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
+
+    ## Override API Version (automatically detected if not set)
+    ##
+    apiVersion:
+
+    ## Ingress Path
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
+    ## Create an ingress object for the GRPC service. This requires an HTTP/2
+    ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
+    ## - ingress.kubernetes.io/protocol: h2c
+    ## - service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    ## - service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    ## For more information see https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/
+    ## and also the documentation for your ingress controller.
+    ##
+    ## The options that are accepted are identical to the HTTP one listed above
+    grpc:
+      enabled: false
+      certManager: false
+      hostname: thanos-grpc.local
+      annotations: {}
+
+      ## The list of additional hostnames to be covered with this ingress record.
+      ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+      # extraHosts:
+      # - name: thanos-grpc.local
+      #   path: /
+
+      ## The tls configuration for additional hostnames to be covered with this ingress record.
+      ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      # extraTls:
+      # - hosts:
+      #     - thanos-grpc.local
+      #   secretName: thanos-grpc.local-tls
+
+      ## If you're providing your own certificates, please use this to add the certificates as secrets
+      ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+      ## -----BEGIN RSA PRIVATE KEY-----
+      ##
+      ## name should line up with a tlsSecret set further up
+      ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+      ##
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ##
+      secrets: []
+      # - name: thanos-grpc.local-tls
+      #   key:
+      #   certificate:
+
+      ## Override API Version (automatically detected if not set)
+      ##
+      apiVersion:
+
+      ## Ingress Path
+      ##
+      path: /
+
+      ## Ingress Path type
+      ##
+      pathType: ImplementationSpecific
+
+## Thanos Query Frontend parameters
+##
+queryFrontend:
+  ## Set to true to enable Thanos Query Frontend component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for Query Frontend
+    ##
+    # existingServiceAccount: query-frontend-service-account
+
+  extraFlags: []
+
+  ## Thanos Query Frontend Cache Configuration
+  ## Specify content for config.yml
+  ##
+  # config:
+
+  ## ConfigMap with Thanos Query Frontend Cache Configuration
+  ## NOTE: This will override queryFrontend.config
+  ##
+  # existingConfigmap:
+
+  ## Number of Thanos Query Frontend replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Query Frontend pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Query Frontend pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Query Frontend node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Query Frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: queryFrontend.podAffinityPreset, queryFrontend.podAntiAffinityPreset, and queryFrontend.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Query Frontend pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Query Frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for query frontend pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Query Frontend pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  # Create ClusterRole and ClusterRolebing for the Service account
+  rbac:
+    create: false
+
+  # Create PodSecurity Policy
+  pspEnabled: false
+
+  ## Thanos Query Frontend containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Query Frontend pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Query Frontend service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ##
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: false
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPU: 50
+    #  targetMemory: 50
+
+  ## Query Frontend Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Query Frontend
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
+    #   pathType: ImplementationSpecific
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
+
+    ## Override API Version (automatically detected if not set)
+    ##
+    apiVersion:
+
+    ## Ingress Path
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
+## Thanos Bucket Web parameters
+##
+bucketweb:
+  ## Set to true to enable Thanos Bucket Web component
+  ##
+  enabled: false
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for bucketweb
+    ##
+    # existingServiceAccount: bucketweb-service-account
+
+  ## Refresh interval to download metadata from remote storage
+  ##
+  refresh: 30m
+
+  ## Timeout to download metadata from remote storage
+  ##
+  timeout: 5m
+
+  ## Extra Flags to passed to Bucket Web
+  ##
+  extraFlags: []
+
+  ## Number of Thanos Query replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Bucket Web pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Bucket Web pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Bucket Web node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Bucket Web pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: bucketweb.podAffinityPreset, bucketweb.podAntiAffinityPreset, and bucketweb.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Bucket Web pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Bucket Web pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for bucketweb pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Bucket Web pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Bucket Web containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Bucket Web pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Bucket Web service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 8080
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Bucket Web Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Bucketweb
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos-bucketweb.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos-bucketweb.local
+    #   path: /
+    #   pathType: ImplementationSpecific
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos-bucketweb.local
+    #   secretName: thanos-bucketweb.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+
+    ## When specifying cert-manager.io/cluster-issuer: nameOfClusterIssuer annotation, enable tls for ingress
+    ##
+    tls: false
+
+    secrets: []
+    # - name: thanos-bucketweb.local-tls
+    #   key:
+    #   certificate:
+
+    ## Override API Version (automatically detected if not set)
+    ##
+    apiVersion:
+
+    ## Ingress Path
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
+## Thanos Compactor parameters
+##
+compactor:
+  ## Set to true to enable Thanos Compactor component
+  ##
+  enabled: false
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for compactor
+    ##
+    # existingServiceAccount: compactor-service-account
+
+  ## Resolution and Retention flags
+  ##
+  retentionResolutionRaw: 30d
+  retentionResolution5m: 30d
+  retentionResolution1h: 10y
+
+  ## Minimum age of fresh (non-compacted) blocks
+  ## before they are being processed
+  ##
+  consistencyDelay: 30m
+
+  ## Extra Flags to passed to Thanos Compactor
+  ##
+  extraFlags: []
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Thanos Compactor pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Compactor pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Compactor node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Compactor pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: compactor.podAffinityPreset, compactor.podAntiAffinityPreset, and compactor.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Compactor pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Compactor pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for compactor pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Compactor pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Compactor containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Compactor pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Compactor service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+  ## Persistence parameters
+  ##
+  persistence:
+    enabled: true
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    # existingClaim:
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## Persistent Volume Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## Persistent Volume Claim size
+    ##
+    size: 8Gi
+
+## Thanos Store Gateway parameters
+##
+storegateway:
+  ## Set to true to enable Thanos Store Gateway component
+  ##
+  enabled: false
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for storegateway
+    ##
+    # existingServiceAccount: storegateway-service-account
+
+  ## Extra Flags to passed to Thanos Store Gateway
+  ##
+  extraFlags: []
+
+  ## Store Gateway Cache Configuration
+  ## Specify content for config.yml
+  ##
+  # config:
+
+  ## ConfigMap with Store Gateway Cache  Configuration
+  ## NOTE: This will override storegateway.config
+  ##
+  # existingConfigmap:
+
+  ## Number of Thanos Store Gateway replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or OnDelete by default.
+  ##
+  updateStrategyType: RollingUpdate
+
+  ## Statefulset Pod management policy: OrderedReady (default) or Parallel.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: OrderedReady
+
+  ## Thanos Store Gateway pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Store Gateway pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Store Gateway node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Store Gateway pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: storegateway.podAffinityPreset, storegateway.podAntiAffinityPreset, and storegateway.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Store Gateway pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Store Gateway pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for storegateway pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Store Gateway pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Store Gateway containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Store Gateway pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Store Gateway service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+    ## Create additional Headless service
+    ##
+    additionalHeadless: false
+
+  ## Persistence parameters
+  ##
+  persistence:
+    enabled: true
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    # existingClaim:
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## Persistent Volume Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## Persistent Volume Claim size
+    ##
+    size: 8Gi
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: false
+    #  minReplicas: 1
+    #  maxReplicas: 11
+    #  targetCPU: 50
+    #  targetMemory: 50
+
+  ## Store Gateway Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+## Thanos Ruler parameters
+##
+ruler:
+  ## Set to true to enable Thanos Ruler component
+  ##
+  enabled: false
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for ruler
+    ##
+    # existingServiceAccount: ruler-service-account
+
+  ## Dynamically configure Query APIs using DNS discovery
+  ##
+  dnsDiscovery:
+    enabled: true
+
+  ## Alermanager URLs array
+  ##
+  alertmanagers: []
+
+  ## The default evaluation interval to use
+  ##
+  evalInterval: 1m
+
+  ## Used to set the 'ruler_cluster' label
+  ##
+  # clusterName:
+
+  ## Extra Flags to passed to Thanos Ruler
+  ##
+  extraFlags: []
+
+  ## Ruler Configuration
+  ## Specify content for ruler.yml
+  ##
+  # config:
+
+  ## ConfigMap with Ruler Configuration
+  ## NOTE: This will override ruler.config
+  ##
+  # existingConfigmap:
+
+  ## Number of Thanos Ruler replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or OnDelete by default.
+  ##
+  updateStrategyType: RollingUpdate
+
+  ## Statefulset Pod management policy: OrderedReady (default) or Parallel.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: OrderedReady
+
+  ## Thanos Ruler pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Thanos Ruler pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Thanos Ruler node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for Thanos Ruler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: ruler.podAffinityPreset, ruler.podAntiAffinityPreset, and ruler.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for Thanos Ruler pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for Thanos Ruler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for ruler pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Ruler pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Ruler containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Thanos Ruler pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Service parameters
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Thanos Ruler service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations: {}
+    ## Use to override service selector labels
+    ##
+    labelSelectorsOverride: {}
+
+    ## Create additional Headless service
+    ##
+    additionalHeadless: false
+
+  ## Persistence parameters
+  ##
+  persistence:
+    enabled: true
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    # existingClaim:
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## Persistent Volume Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## Persistent Volume Claim size
+    ##
+    size: 8Gi
+
+  ## Ruler Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+## Prometheus metrics
+##
+metrics:
+  enabled: false
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: false
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+    ## Labels to add to the ServiceMonitor object
+    ##
+    # labels:
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+## Init Container parameters
+## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
+## values from the securityContext section of the component
+##
+volumePermissions:
+  enabled: false
+  ## Bitnami Minideb image
+  ## ref: https://hub.docker.com/r/bitnami/minideb/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+## MinIO(TM) Chart configuration
+##
+minio:
+  ## Set to true to deploy a MinIO(TM) chart
+  ## to be used as an objstore for Thanos
+  ##
+  enabled: false
+
+  ## MinIO(TM) credentials
+  ##
+  accessKey:
+    password: ''
+  secretKey:
+    password: ''
+
+  ## Default MinIO(TM) buckets
+  ##
+  defaultBuckets: 'thanos'


### PR DESCRIPTION
Helm 패키지 제공이 중단된 아래 차트들을 현재 사용하는 버전으로 가져왔습니다.
- kube-state-metrics: https://charts.bitnami.com/bitnami / 1.1.3
- thanos: https://charts.bitnami.com/bitnami / 3.4.0

업스트림 최신 버전과 차이가 많이 나고 있어 추후 반영이 필요하고 임시 방안으로 적용하려고 합니다.