### PR TITLE
cluster-api-aws: fix missing image value for the job

### DIFF
--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -102,6 +102,12 @@ machineDeployment: []
 #     maxPrice: ''
 #     # MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
 
+job:
+  image:
+    repository: ghcr.io/openinfradev/python_kubectl_argo
+    pullPolicy: IfNotPresent
+    tag: v1.1.0
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
value 파일 정리하면서 잘못 제거된 내용이 있어서 다시 복구합니다.