### PR TITLE
kubernetes-addons: remove storage class

### DIFF
--- a/kubernetes-addons/templates/storageclass.yaml
+++ b/kubernetes-addons/templates/storageclass.yaml
@@ -1,9 +1,0 @@
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-  name: taco-storage
-provisioner: ebs.csi.aws.com
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer

--- a/kubernetes-addons/values.yaml
+++ b/kubernetes-addons/values.yaml
@@ -1,6 +1,3 @@
 cni:
   calico:
     enabled: true
-
-storageclass:
-  enabled: true


### PR DESCRIPTION
스토리지 클래스는 각 스토리지 프로바이더/CSI 드라이버에서 배포하기 때문에 kubernetes-addons 내용은 제거합니다.