### PR TITLE
fluentbit에서 throttle 기능 수행

### DIFF
--- a/fluentbit-operator/README.md
+++ b/fluentbit-operator/README.md
@@ -7,9 +7,9 @@
 
 This chart will do the following:
 
-* Install FluentBit-Oprator
 * Install Fluent Bit Custom Resource Definition
 * Generat Fluent Bit Custom Resource with various cofigurations
 
 ## Installing the Chart
 
+## Caution

--- a/fluentbit-operator/examples/multi-es.valueoverride.yaml
+++ b/fluentbit-operator/examples/multi-es.valueoverride.yaml
@@ -186,6 +186,8 @@ fluentbit:
     path: /var/log/containers/*.log
     tag: kube.*
     type: fluent
+    extraArgs:
+      multilineParser: docker, cri
   - name: syslog
     do_not_store_as_default: false
     es_name: taco-es

--- a/fluentbit-operator/examples/multi-es.valueoverride.yaml
+++ b/fluentbit-operator/examples/multi-es.valueoverride.yaml
@@ -182,6 +182,11 @@ fluentbit:
       key: $kubernetes['container_name']
       value: csi-rbdplugin
 #      value: cap[a-z,\-,0-9]+|ceph[a-z,\-,0-9]+
+      throttle:
+        interval: 1m
+        printStatus: true
+        rate: 10
+        window: 3
     parser: docker
     path: /var/log/containers/*.log
     tag: kube.*

--- a/fluentbit-operator/examples/single-es.valueoverride.yaml
+++ b/fluentbit-operator/examples/single-es.valueoverride.yaml
@@ -195,6 +195,8 @@ fluentbit:
     path: /var/log/containers/*.log
     tag: kube.*
     type: fluent
+    extraArgs:
+      multilineParser: docker, cri
   - name: syslog
     do_not_store_as_default: false
     es_name: taco-es

--- a/fluentbit-operator/templates/fluentbit/filters.yaml
+++ b/fluentbit-operator/templates/fluentbit/filters.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.fluentbit.enabled }}
+{{- $envAll := . }}
+
 apiVersion: logging.kubesphere.io/v1alpha2
 kind: Filter
 metadata:
@@ -45,6 +47,13 @@ spec:
       - {{ printf "$log (%v) m_%v.$TAG true" .regex .severity }}
 {{- end }}
       emitterName: alertrule_match
+---
+{{- range .Values.fluentbit.targetLogs }}
+  {{- tuple $envAll . | include "fluentbit-operator.fluentbit.filter.throttle" }}
+  {{- range .multi_index }}
+    {{- tuple $envAll . | include "fluentbit-operator.fluentbit.filter.throttle" }}
+  {{- end}}
+{{- end}}
 ---
 apiVersion: logging.kubesphere.io/v1alpha2
 kind: Filter

--- a/fluentbit-operator/templates/fluentbit/outputs.yaml
+++ b/fluentbit-operator/templates/fluentbit/outputs.yaml
@@ -31,7 +31,7 @@ data:
   {{- end }}
 {{- end }}
 
-{{ if and $envAll.Values.fluentbit.outputs.http.enabled }}
+{{- if and $envAll.Values.fluentbit.outputs.http.enabled }}
 ---
 # regex-based log exporter
 apiVersion: logging.kubesphere.io/v1alpha2


### PR DESCRIPTION
<h2>Throttle</h2>
<p><a href="https://docs.fluentbit.io/manual/v/1.0/filter/throttle">Throttle이라는 플러그인</a>을 사용하면 시간당 수집되는 로그중 임계치 이상의 경우 이를 버린다.</p>
<h3>설정</h3>


key | type | memo.
-- | -- | --
Rate | integer | 시간당 처리할 최대량
Window | integer | 평균을 계산할 시간간격, 기본값은 5
Interval | string | sleep 형식으로 작성된 시간간격, 3s / 1.5m / 0.5h….
Print_Status | bool | throttle의 동작에 의한 내부 통계치르출력할 것인가?


<h3>동작</h3>
<ul>
<li>interval 시간동안 평균을 구한다.</li>
<li>window 만큼의 과거 시간동안의 처리수를 대상으로 한다.</li>
<li>처리된 로그가 rate까지만 처리하고 이후 들어오는 로그는 버린다.</li>
<li>rate 5, window 5, interval 1s로 설정된 상황에서의 예시
<ul>
<li>3초동안 로그들이 (1개) (3개) (5개) 들어오고 있다면 문제없이 모두 처리</li>
<li>(1개) (3개) (5개) (10개) (6개)  들어와도 아직까지는 평균이 5이므로 문제없음</li>
<li>(1개) (3개) (5개) (10개) (6개) (4개) 들어오면 window는 2초~6초이고 이 값들의 평균은 5를 넘어선다. 따라서 3개가 버려지고 (1개) (3개) (5개) (10개) (6개) (1개)로 처리된다.</li>
<li>바로 다음단계는 당연히 최대 3개….</li>
</ul>
</li>
</ul>
