### PR TITLE
fluentbit: support loki and custom parser

### DIFF
--- a/fluentbit-resource/Chart.yaml
+++ b/fluentbit-resource/Chart.yaml
@@ -13,5 +13,7 @@ maintainers:
 name: fluentbit-resource
 sources:
 - https://github.com/intelliguy/fluentbit-operator
-version: 1.0.0
-# Support Multi-ElasticSeach clusters (1.3)
+version: 1.1.0
+# Support Multi-ElasticSeach clusters (1.0.0)
+# Support loki (1.1.0)
+# Support Custom Parser with Parser CR (1.1.0)

--- a/fluentbit-resource/examples/taco.yaml
+++ b/fluentbit-resource/examples/taco.yaml
@@ -17,6 +17,14 @@ fluentbit:
       nodeSelector:
         taco-lma: enabled
 
+  parsers:
+  - name: taco-syslog-parser-for-ubuntu # modified from syslog-rfc3164
+    regex:
+      regex: '^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
+      timeFormat: '%d/%b/%Y:%H:%M:%S %z'
+      timeKeep: false
+      timeKey: 'time'
+
   outputs:
     es:
     - name: taco-es
@@ -107,6 +115,10 @@ fluentbit:
               number_of_replicas: 1
               index.lifecycle.name: hot-delete-14days
               index.lifecycle.rollover_alias: syslog
+    loki: 
+    - name: taco-loki
+      host: loki
+      port: 3100
   targetLogs:
   - tag: kube.*
     bufferChunkSize: 2M
@@ -114,21 +126,24 @@ fluentbit:
     do_not_store_as_default: false
     es_name: taco-es
     index: container
+    loki_name: taco-loki
     memBufLimit: 20MB
     multi_index:
     - index: platform
       es_name: taco-es
+      loki_name: taco-loki
       key: $kubernetes['namespace_name']
       value: kube-system|taco-system|lma|argo
     parser: docker
     path: /var/log/containers/*.log
-    type: fluent
+    type: kubernates
     extraArgs:
       multilineParser: docker, cri
   - tag: syslog.*
     es_name: taco-es
+    loki_name: taco-loki
     index: syslog
-    parser: syslog-rfc5424
+    parser: taco-syslog-parser-for-ubuntu
     path: /var/log/syslog
     type: syslog
 

--- a/fluentbit-resource/templates/fluentbit/filters.yaml
+++ b/fluentbit-resource/templates/fluentbit/filters.yaml
@@ -38,9 +38,10 @@ spec:
 {{- range .Values.fluentbit.exclude }}
       - {{ printf "%v ^(%v)$ intended_drop.$TAG false" .key .value }}
 {{- end }}
-{{- range .Values.fluentbit.targetLogs }}
-  {{- range .multi_index }}
-      - {{ printf "%v ^(%v)$ seperate.%v.$TAG false" .key .value .index }}
+{{- range $i, $log := .Values.fluentbit.targetLogs }}
+  {{- range $j, $multi := $log.multi_index }}
+    {{- $newTag := tuple "seperate" $log $j | include "fluentbit-operator.fluentbit.newTag" | trimSuffix ".*"  }}
+      - {{ printf "%v ^(%v)$ %v.$TAG false" $multi.key $multi.value $newTag }}
   {{- end}}
 {{- end}}
 {{- range .Values.fluentbit.alerts.rules }}

--- a/fluentbit-resource/templates/fluentbit/outputs.yaml
+++ b/fluentbit-resource/templates/fluentbit/outputs.yaml
@@ -12,23 +12,35 @@ type: Opaque
 data:
   username: {{ .dedicatedUser.username | b64enc }}
   password: {{ .dedicatedUser.password | b64enc }}
-
+# outputs for elasticsearch
   {{- $es := . -}}
-  {{- range $i, $input := $envAll.Values.fluentbit.targetLogs }}
-    {{- $log := . -}}
-    {{- if and (not $input.do_not_store_as_default) (eq .es_name $es.name) }}
----
-    {{- tuple  $envAll $es .type $input.index $input.tag | include "fluentbit-operator.fluentbit.output.es" }}
+  {{- range $i, $log := $envAll.Values.fluentbit.targetLogs }}
+    {{- if and (not $log.do_not_store_as_default) (eq .es_name $es.name) }}
+      {{- tuple  $envAll $es $log.type $log.index $log.tag | include "fluentbit-operator.fluentbit.output.es" }}
     {{- end }}
-    {{ range $input.multi_index }}
+    {{- range $j, $multi := $log.multi_index }}
       {{- if  eq .es_name $es.name  }}
----
-      {{- $newTag := (printf "seperate.%s.*" .index) }}
-    # all, es, type, name, tag, index
-      {{- tuple  $envAll $es $log.type .index $newTag .index | include "fluentbit-operator.fluentbit.output.es" }}
+        {{- $newTag := tuple "seperate" $log $j | include "fluentbit-operator.fluentbit.newTag" }}
+        {{- tuple  $envAll $es $log.type .index $newTag .index | include "fluentbit-operator.fluentbit.output.es" }}
       {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}
+
+{{ range .Values.fluentbit.outputs.loki }}
+  {{- $loki := . }}
+# outputs for loki
+  {{- range $i, $log := $envAll.Values.fluentbit.targetLogs }}
+    {{- if and (not $log.do_not_store_as_default) (eq .loki_name $loki.name) }}
+      {{- tuple  $envAll $loki $log.type $log.index $log.tag | include "fluentbit-operator.fluentbit.output.loki" }}
+    {{- end }}
+    {{- range $j, $multi := $log.multi_index }}
+      {{- if eq $multi.loki_name $loki.name }}
+        {{- $newTag := tuple "seperate" $log $j | include "fluentbit-operator.fluentbit.newTag" }}
+        {{- tuple $envAll $loki $log.type $multi.index $newTag | include "fluentbit-operator.fluentbit.output.loki" }}
+      {{- end}}
+    {{- end}}
+  {{- end}}
 {{- end }}
 
 {{- if and $envAll.Values.fluentbit.outputs.http.enabled }}

--- a/fluentbit-resource/templates/fluentbit/parsers.yaml
+++ b/fluentbit-resource/templates/fluentbit/parsers.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.fluentbit.enabled }}
+{{- range $parser := .Values.fluentbit.parsers }}
+---
+apiVersion: logging.kubesphere.io/v1alpha2
+kind: Parser
+metadata:
+  name: {{ $parser.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    logging.kubesphere.io/enabled: "true"
+    app.kubernetes.io/version: v0.0.1
+spec:
+  {{- range list "decoders" "json" "logfmt" "ltsv" "regex" }}
+    {{- $k := . }}
+    {{- if (index $parser $k ) }}
+{{ $k| indent 2}}:
+{{ toYaml ( index $parser $k ) | indent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/fluentbit-resource/values.yaml
+++ b/fluentbit-resource/values.yaml
@@ -33,6 +33,7 @@ image:
     tag: newton
     pullPolicy: IfNotPresent
 
+
 ## Deploy a Fluentbit instance
 ##
 fluentbit:
@@ -128,6 +129,15 @@ fluentbit:
       # requests:
       #   memory: 400Mi
 
+  parsers: [ ]
+  # - name: taco-syslog-parser-for-ubuntu # modified from syslog-rfc3164
+  #   parser:
+  #     regex:
+  #       regex: '^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
+  #       timeFormat: '%d/%b/%Y:%H:%M:%S %z'
+  #       timeKeep: false
+  #       timeKey: 'time'
+
   targetLogs: [ ]
   # - tag: kube.*
   #   bufferChunkSize: 2M
@@ -151,7 +161,7 @@ fluentbit:
   #   path: /var/log/syslog
   #   type: syslog
   outputs:
-    es: [ ]
+    es: []
     # - name: taco-es
     #   host: eck-elasticsearch-es-http
     #   port: 9200
@@ -168,85 +178,79 @@ fluentbit:
     #       json:
     #         policy:
     #           phases:
+    #             delete:
+    #               actions:
+    #                 delete: {}
+    #               min_age: 14d
     #             hot:
     #               actions:
     #                 rollover:
-    #                   max_size: 30gb
     #                   max_age: 1d
     #                   max_docs: 5000000000
+    #                   max_size: 30gb
     #                 set_priority:
     #                   priority: 100
-    #             delete:
-    #               min_age: 14d
-    #               actions:
-    #                 delete: {}
     #     - name: hot-delete-7days
     #       json:
     #         policy:
     #           phases:
+    #             delete:
+    #               actions:
+    #                 delete: {}
+    #               min_age: 7d
     #             hot:
     #               actions:
     #                 rollover:
-    #                   max_size: 30gb
     #                   max_age: 1d
     #                   max_docs: 5000000000
+    #                   max_size: 30gb
     #                 set_priority:
     #                   priority: 100
-    #             delete:
-    #               min_age: 7d
-    #               actions:
-    #                 delete: {}
     #     - name: hot-delete-3hour
     #       json:
     #         policy:
     #           phases:
+    #             delete:
+    #               actions:
+    #                 delete: {}
+    #               min_age: 3h
     #             hot:
     #               actions:
     #                 rollover:
-    #                   max_size: 30gb
     #                   max_age: 1h
     #                   max_docs: 5000000000
+    #                   max_size: 30gb
     #                 set_priority:
     #                   priority: 100
-    #             delete:
-    #               min_age: 3h
-    #               actions:
-    #                 delete: {}
     #     templates:
     #     - name: platform
     #       json:
-    #         index_patterns: "platform*"
+    #         index_patterns: platform*
     #         settings:
-    #           refresh_interval: 30s
-    #           number_of_shards: 3
-    #           number_of_replicas: 1
     #           index.lifecycle.name: hot-delete-14days
     #           index.lifecycle.rollover_alias: platform
-    #     - name: application
-    #       json:
-    #         index_patterns: "container*"
-    #         settings:
-    #           refresh_interval: 30s
-    #           number_of_shards: 3
     #           number_of_replicas: 1
-    #           index.lifecycle.name: hot-delete-3hour
-    #           index.lifecycle.rollover_alias: container
+    #           number_of_shards: 3
+    #           refresh_interval: 30s
     #     - name: syslog
     #       json:
-    #         index_patterns: "syslog*"
+    #         index_patterns: syslog*
     #         settings:
-    #           refresh_interval: 30s
-    #           number_of_shards: 2
-    #           number_of_replicas: 1
     #           index.lifecycle.name: hot-delete-14days
     #           index.lifecycle.rollover_alias: syslog
-
+    #           number_of_replicas: 1
+    #           number_of_shards: 2
+    #           refresh_interval: 30s
     kafka:
       enabled: false
       # broker: my-kafka-0.my-kafka-headless.lma.svc.cluster.local:9092,
       # topics: taco
     http:
       enabled: false
+    loki: []
+    # - name: taco-loki
+    #   host: loki
+    #   port: 3100
 
   alerts:
     enabled: false


### PR DESCRIPTION
- loki 지원
  - log를 저장하는 backend로 loki나 es 혹은 둘다를 선택할 수 있다.
- custom parser 추가
  - syslog관련하여 parser가 필요한 부분에 대한 보완책으로 개발함
  - upstream에 기본 파서로 등재하도록 요청중 (https://github.com/fluent/fluent-operator/issues/374)