### PR TITLE
fluentbit-resource: add defense codes in jobs for empty elasticsearch…

### DIFF
--- a/fluentbit-resource/examples/taco-es.yaml
+++ b/fluentbit-resource/examples/taco-es.yaml
@@ -1,0 +1,169 @@
+fullnameOverride: fbcr-taco
+
+fluentbit:
+  enabled: true
+
+  daemonset:
+    spec:
+      pod:
+        tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node-role.kubernetes.io/node
+          operator: Exists
+
+  job:
+    spec:
+      nodeSelector:
+        taco-lma: enabled
+
+  parsers:
+  - name: taco-syslog-parser-for-ubuntu # modified from syslog-rfc3164
+    regex:
+      regex: '^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
+      timeFormat: '%d/%b/%Y:%H:%M:%S %z'
+      timeKeep: false
+      timeKey: 'time'
+
+  outputs:
+    es:
+    - name: taco-es
+      host: eck-elasticsearch-es-http
+      port: 9200
+
+      dedicatedUser: 
+        username: taco-fluentbit
+        password: password
+        elasticPasswordSecret: eck-elasticsearch-es-elastic-user
+      
+      template:
+        enabled: true
+        ilms:
+        - name: hot-delete-14days
+          json:
+            policy:
+              phases:
+                hot:
+                  actions:
+                    rollover:
+                      max_size: 30gb
+                      max_age: 1d
+                      max_docs: 5000000000
+                    set_priority:
+                      priority: 100
+                delete:
+                  min_age: 14d
+                  actions:
+                    delete: {}
+        - name: hot-delete-7days
+          json:
+            policy:
+              phases:
+                hot:
+                  actions:
+                    rollover:
+                      max_size: 30gb
+                      max_age: 1d
+                      max_docs: 5000000000
+                    set_priority:
+                      priority: 100
+                delete:
+                  min_age: 7d
+                  actions:
+                    delete: {}
+        - name: hot-delete-3hour
+          json:
+            policy:
+              phases:
+                hot:
+                  actions:
+                    rollover:
+                      max_size: 30gb
+                      max_age: 1h
+                      max_docs: 5000000000
+                    set_priority:
+                      priority: 100
+                delete:
+                  min_age: 3h
+                  actions:
+                    delete: {}
+        templates:
+        - name: platform
+          json:
+            index_patterns: "platform*"
+            settings:
+              refresh_interval: 30s
+              number_of_shards: 3
+              number_of_replicas: 1
+              index.lifecycle.name: hot-delete-14days
+              index.lifecycle.rollover_alias: platform
+        - name: application
+          json:
+            index_patterns: "container*"
+            settings:
+              refresh_interval: 30s
+              number_of_shards: 3
+              number_of_replicas: 1
+              index.lifecycle.name: hot-delete-3hour
+              index.lifecycle.rollover_alias: container
+        - name: syslog
+          json:
+            index_patterns: "syslog*"
+            settings:
+              refresh_interval: 30s
+              number_of_shards: 2
+              number_of_replicas: 1
+              index.lifecycle.name: hot-delete-14days
+              index.lifecycle.rollover_alias: syslog
+  targetLogs:
+  - tag: kube.*
+    bufferChunkSize: 2M
+    bufferMaxSize: 5M
+    do_not_store_as_default: false
+    es_name: taco-es
+    index: container
+    memBufLimit: 20MB
+    multi_index:
+    - index: platform
+      es_name: taco-es
+      key: $kubernetes['namespace_name']
+      value: kube-system|taco-system|lma|argo
+    parser: docker
+    path: /var/log/containers/*.log
+    type: kubernates
+    extraArgs:
+      multilineParser: docker, cri
+  - tag: syslog.*
+    es_name: taco-es
+    index: syslog
+    parser: taco-syslog-parser-for-ubuntu
+    path: /var/log/syslog
+    type: syslog
+
+  alerts:
+    enabled: true
+    namespace: taco-system
+    message: |-
+      {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.taco_cluster }}/{{ $labels.namespace }} ) generate a error due to log = {{ $labels.log }}
+    summary: |-
+      {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.taco_cluster }}/{{ $labels.namespace }} ) generate a error
+    rules:
+    # - name: critical-example
+    #   severity: critical
+    #   regex: "OOM Killed|Evict"
+    - name: warning-example
+      severity: warning
+      regex: "update.?error"
+
+  clusterName: taco-cluster.local
+  exclude:
+  - key: $kubernetes['container_name']
+    value: kibana|elasticsearch|fluent-bit
+
+logExporter:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+  spec:
+    nodeSelector:
+      taco-lma: enabled

--- a/fluentbit-resource/examples/taco-loki.yaml
+++ b/fluentbit-resource/examples/taco-loki.yaml
@@ -1,0 +1,85 @@
+fullnameOverride: fbcr-taco
+
+fluentbit:
+  enabled: true
+
+  daemonset:
+    spec:
+      pod:
+        tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node-role.kubernetes.io/node
+          operator: Exists
+
+  job:
+    spec:
+      nodeSelector:
+        taco-lma: enabled
+
+  parsers:
+  - name: taco-syslog-parser-for-ubuntu # modified from syslog-rfc3164
+    regex:
+      regex: '^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$'
+      timeFormat: '%d/%b/%Y:%H:%M:%S %z'
+      timeKeep: false
+      timeKey: 'time'
+
+  outputs:
+    loki: 
+    - name: taco-loki
+      host: loki
+      port: 3100
+
+  targetLogs:
+  - tag: kube.*
+    bufferChunkSize: 2M
+    bufferMaxSize: 5M
+    do_not_store_as_default: false
+    index: container
+    loki_name: taco-loki
+    memBufLimit: 20MB
+    multi_index:
+    - index: platform
+      loki_name: taco-loki
+      key: $kubernetes['namespace_name']
+      value: kube-system|taco-system|lma|argo
+    parser: docker
+    path: /var/log/containers/*.log
+    type: kubernates
+    extraArgs:
+      multilineParser: docker, cri
+  - tag: syslog.*
+    loki_name: taco-loki
+    index: syslog
+    parser: taco-syslog-parser-for-ubuntu
+    path: /var/log/syslog
+    type: syslog
+
+  alerts:
+    enabled: true
+    namespace: taco-system
+    message: |-
+      {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.taco_cluster }}/{{ $labels.namespace }} ) generate a error due to log = {{ $labels.log }}
+    summary: |-
+      {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.taco_cluster }}/{{ $labels.namespace }} ) generate a error
+    rules:
+    # - name: critical-example
+    #   severity: critical
+    #   regex: "OOM Killed|Evict"
+    - name: warning-example
+      severity: warning
+      regex: "update.?error"
+
+  clusterName: taco-cluster.local
+  exclude:
+  - key: $kubernetes['container_name']
+    value: kibana|elasticsearch|fluent-bit
+
+logExporter:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+  spec:
+    nodeSelector:
+      taco-lma: enabled

--- a/fluentbit-resource/templates/fluentbit/configmap-files.yaml
+++ b/fluentbit-resource/templates/fluentbit/configmap-files.yaml
@@ -13,6 +13,8 @@ metadata:
     app: {{ template "fluentbit-operator.name" . }}-operator
 {{ include "fluentbit-operator.labels" . | indent 4 }}
 data:
+  dummy: |-
+    dummy 
 {{- range .Values.fluentbit.outputs.es }}
   {{- $es := . }}
   {{- if .dedicatedUser.elasticPasswordSecret }}

--- a/fluentbit-resource/templates/fluentbit/job-create-user.yaml
+++ b/fluentbit-resource/templates/fluentbit/job-create-user.yaml
@@ -25,6 +25,12 @@ spec:
 {{ toYaml .Values.fluentbit.job.spec.nodeSelector | indent 8 }}
   {{- end}}
       containers:
+      - name: dummy
+        image: "{{ $envAll.Values.image.elasticsearchTemplates.repository }}:{{ $envAll.Values.image.elasticsearchTemplates.tag }}"
+        imagePullPolicy: "{{ $envAll.Values.image.elasticsearchTemplates.pullPolicy }}"
+        command:
+        - echo
+        - "dummy: Naver mind"
   {{- range .Values.fluentbit.outputs.es }}
     {{- if .dedicatedUser.elasticPasswordSecret }}
       {{- $esname := .name }}

--- a/fluentbit-resource/templates/fluentbit/job-es-template.yaml
+++ b/fluentbit-resource/templates/fluentbit/job-es-template.yaml
@@ -26,7 +26,12 @@ spec:
 {{ toYaml .Values.fluentbit.job.spec.nodeSelector | indent 8 }}
 {{- end}}
       containers:
-
+      - name: dummy
+        image: "{{ $envAll.Values.image.elasticsearchTemplates.repository }}:{{ $envAll.Values.image.elasticsearchTemplates.tag }}"
+        imagePullPolicy: "{{ $envAll.Values.image.elasticsearchTemplates.pullPolicy }}"
+        command:
+        - echo
+        - "dummy: Naver mind"
   {{- range .Values.fluentbit.outputs.es }}
     {{- if .template.enabled }}
       {{- $esname := .name }}


### PR DESCRIPTION
… setting

- elasticsearch에 대한 정의가 없는경우 es관련 초기화 job에서 에러발생함 -> 이를 방지하는 dummy 코드 추가
  - 이 에러는 각 세부작업별로 별도 컨테이너를 띄워 동작시키는 방식에서 초기화 필요가 하나도 없는 경우 pod 구성상 에러 발생
- 예제 파일에 loki만 또는 es만 사용하는 케이스에 대한 재지정 값 예시 추가