### PR TITLE
fluentbit: change crd from kubesphere.io to fluent.io

### DIFF
--- a/fluentbit-resource/Chart.yaml
+++ b/fluentbit-resource/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 name: fluentbit-resource
 sources:
 - https://github.com/intelliguy/fluentbit-operator
-version: 1.1.0
+version: 1.2.0
 # Support Multi-ElasticSeach clusters (1.0.0)
 # Support loki (1.1.0)
 # Support Custom Parser with Parser CR (1.1.0)

--- a/fluentbit-resource/templates/_helpers.tpl
+++ b/fluentbit-resource/templates/_helpers.tpl
@@ -76,13 +76,13 @@ heritage: {{ $.Release.Service | quote }}
 {{- $tag := index . 4 }}
 ---
 # Elasticsearch index {{ $es.index }} in {{ $es.name }}
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Output
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
 metadata:
   name: {{ template "fluentbit-operator.fullname" $envAll  }}-{{ $es.name }}-{{ $index_name }}
   namespace: {{ $envAll.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: {{ $tag | quote }}
@@ -119,13 +119,13 @@ spec:
 {{- $tag := index . 4 -}}
 ---
 # Loki {{ $loki.name }}
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Output
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
 metadata:
   name: {{ template "fluentbit-operator.fullname" $envAll  }}-loki-{{ $loki.name  }}-{{ trimSuffix ".*" $tag  }}
   namespace: {{ $envAll.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: {{ $tag | quote }}
@@ -153,13 +153,13 @@ spec:
 {{- if and $input.index $input.throttle }}
 ---
 # throttle
-apiVersion: logging.kubesphere.io/v1alpha2
+apiVersion: fluentbit.fluent.io/v1alpha2
 kind: Filter
 metadata:
   name: {{ template "fluentbit-operator.fullname" $envAll  }}-throttle-{{ $input.index  }}
   namespace: {{ $envAll.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: seperate.{{ $input.index }}.*

--- a/fluentbit-resource/templates/fluentbit/filters.yaml
+++ b/fluentbit-resource/templates/fluentbit/filters.yaml
@@ -1,13 +1,13 @@
 {{- if and .Values.fluentbit.enabled }}
 {{- $envAll := . }}
 
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Filter
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
 metadata:
   name: kubernetes
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "kube.*"
@@ -56,13 +56,13 @@ spec:
   {{- end}}
 {{- end}}
 ---
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Filter
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
 metadata:
   name: simplify
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "m_*"
@@ -71,13 +71,13 @@ spec:
       operation: lift
       nestedUnder: kubernetes
 ---
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Filter
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
 metadata:
   name: add-info
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "kube*"
@@ -87,13 +87,13 @@ spec:
       - add:
           cluster: {{.Values.fluentbit.clusterName }}
 ---
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Filter
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
 metadata:
   name: add-hostname
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "kubenode.*"
@@ -104,13 +104,13 @@ spec:
           hostname: ${HOSTNAME}
 {{- range .Values.fluentbit.alerts.rules }}
 ---
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Filter
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
 metadata:
   name: add-{{.severity}}
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "m_{{.severity}}.*"

--- a/fluentbit-resource/templates/fluentbit/fluentbit.yaml
+++ b/fluentbit-resource/templates/fluentbit/fluentbit.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.fluentbit.enabled }}
-apiVersion: logging.kubesphere.io/v1alpha2
+apiVersion: fluentbit.fluent.io/v1alpha2
 kind: FluentBit
 metadata:
   name: fluent-bit

--- a/fluentbit-resource/templates/fluentbit/fluentbitconfig.yaml
+++ b/fluentbit-resource/templates/fluentbit/fluentbitconfig.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.fluentbit.enabled }}
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: FluentBitConfig
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFluentBitConfig
 metadata:
   name: fluent-bit-config
   namespace: {{ $.Release.Namespace }}
@@ -13,11 +13,11 @@ spec:
     logLevel: warning
   inputSelector:
     matchLabels:
-      logging.kubesphere.io/enabled: "true"
+      fluentbit.fluent.io/enabled: "true"
   filterSelector:
     matchLabels:
-      logging.kubesphere.io/enabled: "true"      
+      fluentbit.fluent.io/enabled: "true"      
   outputSelector:
     matchLabels:
-      logging.kubesphere.io/enabled: "true"
+      fluentbit.fluent.io/enabled: "true"
 {{- end}}

--- a/fluentbit-resource/templates/fluentbit/inputs.yaml
+++ b/fluentbit-resource/templates/fluentbit/inputs.yaml
@@ -1,13 +1,13 @@
 {{- if and .Values.fluentbit.enabled }}
 {{- range $i, $input := .Values.fluentbit.targetLogs }}
 ---
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Input
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterInput
 metadata:
   name: input-{{ trimSuffix ".*"  $input.tag }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   tail: 

--- a/fluentbit-resource/templates/fluentbit/outputs.yaml
+++ b/fluentbit-resource/templates/fluentbit/outputs.yaml
@@ -46,13 +46,13 @@ data:
 {{- if and $envAll.Values.fluentbit.outputs.http.enabled }}
 ---
 # regex-based log exporter
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Output
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
 metadata:
   name: {{ template "fluentbit-operator.fullname" $envAll }}-exporter
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "m_*"
@@ -65,13 +65,13 @@ spec:
 {{- if $envAll.Values.fluentbit.outputs.kafka.enabled }}
 ---
 # kafka support
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Output
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
 metadata:
   name: {{ template "fluentbit-operator.fullname" $envAll  }}-kafka
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   match: "kube*"

--- a/fluentbit-resource/templates/fluentbit/parsers.yaml
+++ b/fluentbit-resource/templates/fluentbit/parsers.yaml
@@ -1,13 +1,13 @@
 {{- if and .Values.fluentbit.enabled }}
 {{- range $parser := .Values.fluentbit.parsers }}
 ---
-apiVersion: logging.kubesphere.io/v1alpha2
-kind: Parser
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterParser
 metadata:
   name: {{ $parser.name }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    logging.kubesphere.io/enabled: "true"
+    fluentbit.fluent.io/enabled: "true"
     app.kubernetes.io/version: v0.0.1
 spec:
   {{- range list "decoders" "json" "logfmt" "ltsv" "regex" }}


### PR DESCRIPTION
kubesphere.io에서 만들었던 crd를 fluent.io에서 관리하는 crd로 변경함 

- 지난달 버전(app 1.0)에서는 문제가 있어 기존 crd를 사용하도록 작업했었음
- 금일 e2e에러를 해결하는 기준으로 현재내역을 확인해보니 24일 1.5버전이 release되었고
- 이를 테스트해본결과 정상적으로 동작함을 확인함 (example/taco.yaml 기준) 

다음 내역이 동시에 merge 되어야 합니다.
https://github.com/openinfradev/helm-charts/pull/142
https://github.com/openinfradev/decapod-base-yaml/pull/172
