### PR TITLE
thanos-config: change minio name

### DIFF
--- a/thanos-config/Chart.yaml
+++ b/thanos-config/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: thanos-config
 description: Chart for Thanos configuration 
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.0"

--- a/thanos-config/values.yaml
+++ b/thanos-config/values.yaml
@@ -2,7 +2,7 @@ objectStorage:
   enabled: true
   secretName: thanos-objstore-secret
   bucketName: thanos
-  endpoint: thanos-minio.fed.svc.cluster.local:9000
+  endpoint: minio.fed.svc.cluster.local:9000
   access_key: taco
   secret_key: password
   insecure: true


### PR DESCRIPTION
from thanos-minio to minio
due to change of minio-installation from embeded to single

LOKI들어오면서 minio를 thanos와 loki가 공유하게되었고 
이에 따라 기존 thanos 챠트 내부에서 설치하던 minio를 명시적으로 설치하게됨
-> 이름이 thanos-minio에서 minio로 바뀌었고 이 내역을 반영하기 위한 챠트 수정