### PR TITLE
bugfix. rollback to 8dc2c663475b9e7ddf02ffa9648da39232527263

### DIFF
--- a/servicemesh-kiali-resource/templates/kiali-controlplane.yaml
+++ b/servicemesh-kiali-resource/templates/kiali-controlplane.yaml
@@ -11,8 +11,6 @@ spec:
   deployment:
     ingress_enabled: {{ .Values.deployment.ingress.enabled }}
     namespace: {{ .Values.deployment.namespace }}
-    image_name: {{ .Values.deployment.image_name }}
-    image_version: {{ .Values.deployment.image_version }}
     replicas: {{ .Values.deployment.replicas }}
     resources:
       requests:

--- a/servicemesh-kiali-resource/values.yaml
+++ b/servicemesh-kiali-resource/values.yaml
@@ -4,8 +4,6 @@ deployment:
   ingress:
     enabled: false
   namespace: istio-system
-  image_name: quay.io/kiali/kiali
-  image_version: v1.45.1
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/commit/8dc2c663475b9e7ddf02ffa9648da39232527263

이 push 로 인해 서비스메쉬 생성이 실패하고 있는듯합니다. 하위 호환성 이슈가 있는것 같은데 helm-chart 버전업하면서 변경하는게 좋겠습니다.