### PR TITLE
servicemesh-jaeger-resource: disable es index cleaner cronjob

### DIFF
--- a/servicemesh-jaeger-resource/templates/jaeger-controlplane.yaml
+++ b/servicemesh-jaeger-resource/templates/jaeger-controlplane.yaml
@@ -29,13 +29,13 @@ spec:
   {{- end }}
   storage:
     type: elasticsearch
-    {{- if .Values.storage.esIndexCleaner.enabled }}
     esIndexCleaner:
-      enabled: true
+      enabled: {{ .Values.storage.esIndexCleaner.enabled }}
+      {{- if .Values.storage.esIndexCleaner.enabled }}
       image: {{ .Values.storage.esIndexCleaner.image }}
       numberOfDays: {{ .Values.storage.esIndexCleaner.numberOfDays }}
       schedule: "{{ .Values.storage.esIndexCleaner.schedule }}"
-    {{- end }}
+      {{- end }}
     options:
       es:
         index-prefix: {{ .Values.storage.options.es.indexPrefix }}


### PR DESCRIPTION
Jaeger CRD의 es index cleaner 활성화 여부 기본 값이 true 이기 때문에  사용하지 않을 경우 명시적으로 false로 정의해야 합니다.