### PR TITLE
cluster-api-aws: EKS addon 지원 추가

### DIFF
--- a/cluster-api-aws/Chart.yaml
+++ b/cluster-api-aws/Chart.yaml
@@ -4,6 +4,6 @@ description: A chart to install Kubernetes cluster using Cluster API Provider AW
 
 type: application
 
-version: 0.8.0
+version: 0.8.1
 
 appVersion: "1.0.0"

--- a/cluster-api-aws/templates/aws-managed-cluster.yaml
+++ b/cluster-api-aws/templates/aws-managed-cluster.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.cluster.eksEnabled }}
+apiVersion: {{ .Values.api.group.infrastructure }}/v1beta2
+kind: AWSManagedCluster
+metadata:
+  name: {{ .Values.cluster.name }}
+  namespace: {{ .Release.Namespace }}
+spec: {}
+{{- end }}

--- a/cluster-api-aws/templates/aws-managed-control-plane.yaml
+++ b/cluster-api-aws/templates/aws-managed-control-plane.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Values.cluster.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  eksClusterName: {{ .Values.cluster.name }}
   region: {{ .Values.cluster.region }}
   sshKeyName: {{ .Values.sshKeyName }}
   version: {{ .Values.cluster.kubernetesVersion }}

--- a/cluster-api-aws/templates/aws-managed-control-plane.yaml
+++ b/cluster-api-aws/templates/aws-managed-control-plane.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.cluster.eksEnabled }}
-apiVersion: {{ .Values.api.group.controlplane }}/{{ .Values.api.version }}
+apiVersion: {{ .Values.api.group.controlplane }}/v1beta2
 kind: AWSManagedControlPlane
 metadata:
-  name: "{{ .Values.cluster.name }}-eks-control-plane"
+  name: {{ .Values.cluster.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   region: {{ .Values.cluster.region }}

--- a/cluster-api-aws/templates/aws-managed-control-plane.yaml
+++ b/cluster-api-aws/templates/aws-managed-control-plane.yaml
@@ -9,4 +9,6 @@ spec:
   region: {{ .Values.cluster.region }}
   sshKeyName: {{ .Values.sshKeyName }}
   version: {{ .Values.cluster.kubernetesVersion }}
+  addons:
+    {{- toYaml .Values.cluster.eksAddons | nindent 4 }}
 {{- end }}

--- a/cluster-api-aws/templates/cluster.yaml
+++ b/cluster-api-aws/templates/cluster.yaml
@@ -18,11 +18,11 @@ spec:
     {{- end }}
     name: {{ .Values.cluster.name }}
   controlPlaneRef:
-    apiVersion: {{ .Values.api.group.controlplane }}/{{ .Values.api.version }}
-    name: "{{ .Values.cluster.name }}-control-plane"
     {{- if .Values.cluster.eksEnabled }}
+    apiVersion: {{ .Values.api.group.controlplane }}/v1beta2
     kind: AWSManagedControlPlane
-    name: "{{ .Values.cluster.name }}-eks-control-plane"
     {{- else }}
+    apiVersion: {{ .Values.api.group.controlplane }}/{{ .Values.api.version }}
     kind: KubeadmControlPlane
     {{- end }}
+    name: {{ .Values.cluster.name }}

--- a/cluster-api-aws/templates/cluster.yaml
+++ b/cluster-api-aws/templates/cluster.yaml
@@ -10,15 +10,13 @@ spec:
       cidrBlocks: {{ .Values.cluster.podCidrBlocks }}
   {{- end }}
   infrastructureRef:
-    {{- if .Values.cluster.eksEnabled }}
-    apiVersion: {{ .Values.api.group.controlplane }}/{{ .Values.api.version }}
-    kind: AWSManagedControlPlane
-    name: "{{ .Values.cluster.name }}-eks-control-plane"
-    {{- else }}
     apiVersion: {{ .Values.api.group.infrastructure }}/v1beta2
+    {{- if .Values.cluster.eksEnabled }}
+    kind: AWSManagedCluster
+    {{- else }}
     kind: AWSCluster
-    name: {{ .Values.cluster.name }}
     {{- end }}
+    name: {{ .Values.cluster.name }}
   controlPlaneRef:
     apiVersion: {{ .Values.api.group.controlplane }}/{{ .Values.api.version }}
     name: "{{ .Values.cluster.name }}-control-plane"

--- a/cluster-api-aws/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-aws/templates/kubeadm-control-plane.yaml
@@ -2,7 +2,7 @@
 kind: KubeadmControlPlane
 apiVersion: {{ .Values.api.group.controlplane }}/{{ .Values.api.version }}
 metadata:
-  name: "{{ .Values.cluster.name }}-control-plane"
+  name: {{ .Values.cluster.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kubeadmControlPlane.replicas }}

--- a/cluster-api-aws/templates/machine-pool.yaml
+++ b/cluster-api-aws/templates/machine-pool.yaml
@@ -45,6 +45,7 @@ metadata:
   name: {{ $envAll.Values.cluster.name }}-mp-{{ .name }}
   namespace: {{ $envAll.Release.Namespace }}
 spec:
+  eksNodegroupName: {{ $envAll.Values.cluster.name }}-mp-{{ .name }}
   instanceType: {{ .machineType }}
   diskSize: {{ .rootVolume.size }}
   scaling:

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -6,6 +6,14 @@ cluster:
   name: capi-quickstart
   region: ap-northeast-2
   eksEnabled: false
+  eksAddons: []
+  #  - name: "aws-ebs-csi-driver"
+  #    version: "v1.15.0-eksbuild.1"
+  #    conflictResolution: "overwrite"
+  #    serviceAccountRoleARN: arn:aws:iam::XXXXXXXXXXXX:role/AmazonEKS_EBS_CSI_DriverRole_NAME
+  #  - name: "vpc-cni"
+  #    version: "v1.10.1-eksbuild.1"
+  #    conflictResolution: "overwrite"
   # networkSpec:
     # vpc:
       # id: vpc-id


### PR DESCRIPTION
EKS Addon 지원을 위한 수정 사항입니다. 아래처럼 값을 설정하면 됩니다. EBS CSI 드라이버의 경우 IAM 설정이 추가로 필요하며 이는 tks-flow 에 관련 내용을 추가할 계획입니다.
```
  eksAddons:
    - name: "aws-ebs-csi-driver"
      version: "v1.15.0-eksbuild.1"
      conflictResolution: "overwrite"
      serviceAccountRoleARN: arn:aws:iam::XXXXXXXXXXXX:role/AmazonEKS_EBS_CSI_DriverRole_NAME
    - name: "vpc-cni"
      version: "v1.10.1-eksbuild.1"
      conflictResolution: "overwrite"
```

덧붙여서 일부 누락되거나 혼동이 있었던 부분도 같이 정리하였습니다.
- AWS Managed Cluster 자원 추가
- EKS 자원 이름을 명시적으로 정의 (CAPA 에서 자동으로 만드는 이름은 네임스페이스 정보 등을 포함해서 너무 길게 나타남)

