### PR TITLE
cluster-api-aws: remove unnecessary conditional for POD subnet CIDR

### DIFF
--- a/cluster-api-aws/templates/cluster.yaml
+++ b/cluster-api-aws/templates/cluster.yaml
@@ -4,11 +4,9 @@ metadata:
   name: {{ .Values.cluster.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if not .Values.machinePool }}
   clusterNetwork:
     pods:
       cidrBlocks: {{ .Values.cluster.podCidrBlocks }}
-  {{- end }}
   infrastructureRef:
     apiVersion: {{ .Values.api.group.infrastructure }}/v1beta2
     {{- if .Values.cluster.eksEnabled }}


### PR DESCRIPTION
machinepool 사용 유무와 POD CIDR 지정은 상관이 없는데 추가되어 있었던 조건문을 삭제합니다. 차트 작성 처음부터 들어가 있던 내용인데 이제서야 발견했습니다.