### PR TITLE
add chart for aws resources using ack

### DIFF
--- a/ack-resources/.helmignore
+++ b/ack-resources/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/ack-resources/Chart.yaml
+++ b/ack-resources/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ack-resources
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/ack-resources/templates/taco-s3.yaml
+++ b/ack-resources/templates/taco-s3.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.s3.enabled }}
+{{- $envAll := . }}
+{{- range .Values.s3.name }}
+---
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: {{ . }}
+  namespace: {{ $envAll.Release.Namespace }}
+spec:
+  name: {{ . }}
+  tagging:
+    tagSet:
+    - key: services.tks/generator
+      value: tks.v2023.06.00
+  versioning:
+    status: Enabled
+{{- end }}
+{{- end }}

--- a/ack-resources/values.yaml
+++ b/ack-resources/values.yaml
@@ -1,0 +1,8 @@
+s3: 
+  enabled: False
+  name: 
+  - loki
+  - thanos 
+  
+ec2:
+  enabled: False


### PR DESCRIPTION
ack를 사용하여 aws 자원을 생성한다. 
이를 사용하기 위해서는 해당 자원에 대한 ack 컨트롤러 설치가 선행되어야 한다.
초기 버전에서는 s3를 만들기 위한 챠트를 추가하며 enabled 지정과 name에 다수의 이름을 지정하면 해당 s3를 만들어 준다.