### PR TITLE
cluster-api-aws: fix multiple machinepool definition erros

### DIFF
--- a/cluster-api-aws/templates/machine-pool.yaml
+++ b/cluster-api-aws/templates/machine-pool.yaml
@@ -1,6 +1,6 @@
-{{- $azPostfixList := list "a" "b" "c" "d" "e" "f" }}
 {{- $envAll := . }}
 {{- range .Values.machinePool }}
+---
 apiVersion: {{ $envAll.Values.api.group.cluster }}/{{ $envAll.Values.api.version }}
 kind: MachinePool
 metadata:


### PR DESCRIPTION
다수의 MachinePool 자원을 정의 하였을 때 비정상적인 자원 생성이 되던 오류를 수정하였습니다.