### PR TITLE
lma-addons: fix uid for each dashboard and seperate etcd dashboard fr…

### DIFF
--- a/lma-addons/artifacts/dashboard/etcd-Etcd.json
+++ b/lma-addons/artifacts/dashboard/etcd-Etcd.json
@@ -1433,7 +1433,7 @@
   },
   "timezone": "browser",
   "title": "[TKS] Kubernetes / System / Etcd",
-  "uid": "tks-Cu828uKVz",
+  "uid": "tks_etcd_dashboard",
   "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-ReferenceNodes.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ReferenceNodes.json
@@ -21855,7 +21855,7 @@
   },
   "timezone": "browser",
   "title": "[TKS] Kubernetes / Reference / Nodes",
-  "uid": "tks-HBUxLuKVz",
-  "version": 2,
+  "uid": "tks_refnode_dashboard",
+  "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-SystemAPIServer.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-SystemAPIServer.json
@@ -1305,7 +1305,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "[TKS] Kubernetes / System / API Server",
-  "uid": "tks-dCTfLXKVz",
+  "uid": "tks_kubeapi_dashboard",
   "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-SystemCoreDNS.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-SystemCoreDNS.json
@@ -1598,7 +1598,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "[TKS] Kubernetes / System / CoreDNS",
-  "uid": "tks-eIbpLXK4k",
+  "uid": "tks_coredns_dashboard",
   "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewClusterGlobal.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewClusterGlobal.json
@@ -2520,7 +2520,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "[TKS] Kubernetes / View / Cluster Global",
-  "uid": "tks-6LLuFVz",
+  "uid": "tks_cluster_dashboard",
   "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewNamespaces.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewNamespaces.json
@@ -1649,7 +1649,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "[TKS] Kubernetes / View / Namespaces",
-  "uid": "tks-IcQ5PXK4k",
+  "uid": "tks_namespace_dashboard",
   "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewNodes.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewNodes.json
@@ -3759,7 +3759,7 @@
   },
   "timezone": "browser",
   "title": "[TKS] Kubernetes / View / Nodes",
-  "uid": "tks-UXnoYXF4z",
-  "version": 2,
+  "uid": "tks_node_dashboard",
+  "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewPodsv1.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewPodsv1.json
@@ -3087,7 +3087,7 @@
   },
   "timezone": "browser",
   "title": "[TKS] Kubernetes / View / Pods (v1)",
-  "uid": "tks-ttMuv8FVz",
-  "version": 2,
+  "uid": "tks_podv1_dashboard",
+  "version": 1,
   "weekStart": ""
 }

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewPodsv2.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewPodsv2.json
@@ -1862,7 +1862,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "[TKS] Kubernetes / Views / Pods (v2)",
-  "uid": "tks-ddChEXF4z",
+  "uid": "tks_podv2_dashboard",
   "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
…om kubernetes group

etcd dashboard 를 설치하지 않도록 함
- 기존 값을 통해 배포하면 빠지도록 했음
- 설치하려면 value값에 etcd 추가해야 함 (아래 참조)
```
grafanaDashboard:
  include:
  - kubernetes
  - node
  - etcd 
 ```
 대시보드에 hashcord로 부여되었던 uid를 대시보드명과 맞춰서 추가함