### PR TITLE
add annotation to prevent race between capa and cluster-autoscaler

### DIFF
--- a/cluster-api-aws/templates/machine-pool.yaml
+++ b/cluster-api-aws/templates/machine-pool.yaml
@@ -6,6 +6,10 @@ kind: MachinePool
 metadata:
   name: {{ $envAll.Values.cluster.name }}-mp-{{ .name }}
   namespace: {{ $envAll.Release.Namespace }}
+{{- if $envAll.Values.cluster.eksEnabled }}
+  annotations:
+    cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
+{{- end }}
 spec:
   clusterName: {{ $envAll.Values.cluster.name }}
   replicas: {{ .replicas }}

--- a/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/Chart.yaml
@@ -3,4 +3,4 @@ name: cluster-autoscaler
 description: cluster-autoscaler for cluster-api cloud provder
 type: application
 version: 0.2.0
-appVersion: "1.22.2"
+appVersion: "1.25.2"

--- a/cluster-autoscaler/templates/rbac-for-mgmt-cluster-access.yaml
+++ b/cluster-autoscaler/templates/rbac-for-mgmt-cluster-access.yaml
@@ -26,6 +26,9 @@ rules:
     - machinedeployments/scale
     - machines
     - machinesets
+    - machinepools
+    - machinepools/scale
+    - awsmanagedmachinepools
     verbs:
     - get
     - list

--- a/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/values.yaml
@@ -19,9 +19,9 @@ mgmtKubeconfigSecretName: mgmt-kubeconfig
 replicaCount: 1
 
 image:
-  repository: k8s.gcr.io/autoscaling/cluster-autoscaler
+  repository: harbor-cicd.taco-cat.xyz/tks/cluster-autoscaler
   pullPolicy: IfNotPresent
-  tag: v1.22.2
+  tag: v1.25.2
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
EKS가 활성화된 경우 cluster-autoscaler가 MachinePool (EKS managed nodegroup)의 숫자를 관리하기 때문에 cluster-api-aws 컨트롤러가 관여하지 않도록 annotation을 추가하도록 합니다.

추가로 Self-mananged 클러스터인 경우 사용하는 cluster-autoscaler의 버전을 최신 버전으로 업데이트 하였습니다.