### PR TITLE
cluster-api-aws: add additional nodegroup IAM role policy

### DIFF
--- a/cluster-api-aws/Chart.yaml
+++ b/cluster-api-aws/Chart.yaml
@@ -4,6 +4,6 @@ description: A chart to install Kubernetes cluster using Cluster API Provider AW
 
 type: application
 
-version: 0.8.2
+version: 0.8.3
 
 appVersion: "1.0.0"

--- a/cluster-api-aws/templates/machine-pool.yaml
+++ b/cluster-api-aws/templates/machine-pool.yaml
@@ -53,6 +53,10 @@ spec:
     minSize: {{ .minSize }}
   remoteAccess:
     sshKeyName: {{ $envAll.Values.sshKeyName }}
+  {{- with .roleAdditionalPolicies }}
+  roleAdditionalPolicies:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- else }}
 kind: AWSMachinePool
 metadata:

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -79,6 +79,8 @@ machinePool: []
 #     size: 200
 #   subnets: []
 #   labels: []
+#   roleAdditionalPolicies:
+#   - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 # **this version dosen't support the spot instance, because the aws cluster api provider doesn't support it in awsmachinpool**
 # useSpotInstance:  #spotMarketOptions:
 #   enabled: false


### PR DESCRIPTION
EKS nodegroup (capa AWSManagedMachinePool)의 IAM Role 추가 설정이 가능하도록 수정하였습니다.