### PR TITLE
lma-addons: change some hard-fixed namespace to be defined on deployment

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project
 name: lma-addons
-version: 1.8.3
+version: 1.8.4

--- a/lma-addons/templates/service-monitor/argo-cd.yaml
+++ b/lma-addons/templates/service-monitor/argo-cd.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitor
 kind: ServiceMonitor
 metadata:
   name: argocd-application
-  namespace: lma
+  namespace: {{ $.Release.Namespace }}
   labels:
     release: prometheus-operator
 spec:
@@ -33,7 +33,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitor
 kind: ServiceMonitor
 metadata:
   name: argocd-server
-  namespace: lma
+  namespace: {{ $.Release.Namespace }}
   labels:
     release: prometheus-operator
 spec:

--- a/lma-addons/templates/service-monitor/argo-workflow.yaml
+++ b/lma-addons/templates/service-monitor/argo-workflow.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitor
 kind: ServiceMonitor
 metadata:
   name: argo-workflows-server
-  namespace: lma
+  namespace: {{ $.Release.Namespace }}
   labels:
     release: prometheus-operator
 spec:
@@ -33,7 +33,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheus.crdApiGroup | default "monitor
 kind: ServiceMonitor
 metadata:
   name: argo-workflows-controller
-  namespace: lma
+  namespace: {{ $.Release.Namespace }}
   labels:
     release: prometheus-operator
 spec:


### PR DESCRIPTION
argo의 서비스 모니터관련 자원에 네임스페이스가 코드에 박혀있어 배포시 결정될 수 있도록 수정