### PR TITLE
cluster-api-aws: fix bastion host if eks is enabled

### DIFF
--- a/cluster-api-aws/templates/aws-managed-control-plane.yaml
+++ b/cluster-api-aws/templates/aws-managed-control-plane.yaml
@@ -15,4 +15,14 @@ spec:
   identityRef:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  bastion:
+    enabled: {{ .Values.cluster.bastion.enabled }}
+    {{- if .Values.cluster.bastion.enabled  }}
+    instanceType: {{ .Values.cluster.bastion.instanceType }}
+    disableIngressRules: {{ .Values.cluster.bastion.disableIngressRules }}
+    {{- with .Values.cluster.bastion.allowedCIDRBlocks }}
+    allowedCIDRBlocks:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -35,9 +35,9 @@ cluster:
   bastion:
     enabled: false
     instanceType: t3.micro
-    disableIngressRules: false
-    allowedCIDRBlocks:
-    - 0.0.0.0/0
+    # disableIngressRules: false
+    # allowedCIDRBlocks:
+    # - 0.0.0.0/0
     useSpotInstance:  #spotMarketOptions:
       enabled: true
       maxPrice: ''


### PR DESCRIPTION
EKS일 때 bastion 호스트 설정 반영이 누락되어 인스턴스 생성이 되지 않는 문제점을 수정하였습니다.