### PR TITLE
ack-resources: add controllerability for versioned objects on s3 buckets

### DIFF
--- a/ack-resources/Chart.yaml
+++ b/ack-resources/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ack-resources/templates/buckets.yaml
+++ b/ack-resources/templates/buckets.yaml
@@ -19,7 +19,8 @@ spec:
     - key: services.tks/generator
       value: tks.v2023.06.00
   versioning:
-    status: Enabled
+    status:  {{ .versioning | default Disabled }}
+
 {{- if .policy }}
   policy: |
   {{- .policy | nindent 4}}

--- a/ack-resources/values.yaml
+++ b/ack-resources/values.yaml
@@ -8,8 +8,11 @@ s3:
   # buckets can be defined with a field name, and optionally define a specific policies with a field policy.
   # if policy is not defined, the default policy with Values.tks.iamRoles for tks will be inserted or no policy is defined when Values.tks.iamRoles is not defined.
   # - name: loki
+  #   versioning: Disabled
   #   policy: |
+  #
   # - name: thanos
+  #   versioning: Disabled
   #   policy: |
   
 ec2:


### PR DESCRIPTION
버킷이 비워지지 않아서 클러스터가 삭제되지 않는 버그에 대한 수정입니다.
다음 내역이 한꺼번에 merge되어야 합니다.
- https://github.com/openinfradev/helm-charts/pull/194
- https://github.com/openinfradev/decapod-base-yaml/pull/252
- https://github.com/openinfradev/decapod-site/pull/166