### PR TITLE
ack-resource: config versioning when only it is given

### DIFF
--- a/ack-resources/templates/buckets.yaml
+++ b/ack-resources/templates/buckets.yaml
@@ -18,8 +18,10 @@ spec:
     tagSet:
     - key: services.tks/generator
       value: tks.v2023.06.00
+{{- if .versioning }}
   versioning:
-    status:  {{ .versioning | default "Disabled" }}
+    status:  {{ .versioning }}
+{{- end}}
 
 {{- if .policy }}
   policy: |


### PR DESCRIPTION
bucket의 versioning에 default값 (암것도 안주는)을 사용하도록 변경