### PR TITLE
lma-addons: change some hard-fixed namespace to be defined on deployment

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project
 name: lma-addons
-version: 1.8.5
+version: 1.8.6


### PR DESCRIPTION
argo의 서비스 모니터관련 자원에 네임스페이스가 코드에 박혀있어 배포시 결정될 수 있도록 수정