### PR TITLE
cluster-api-*: make etcd metrics externally accessible

### DIFF
--- a/cluster-api-aws/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-aws/templates/kubeadm-control-plane.yaml
@@ -24,6 +24,10 @@ spec:
       controllerManager:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .etcd }}
+      etcd:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     initConfiguration:
       nodeRegistration:

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -74,6 +74,10 @@ kubeadmControlPlane:
     controllerManager:
       extraArgs:
         cloud-provider: aws # must be defined
+    etcd:
+      local:
+        extraArgs:
+          listen-metrics-urls: "http://0.0.0.0:2381"
 
 machinePool: []
 # You can define machinePool. referce the belows.

--- a/cluster-api-byoh/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-byoh/templates/kubeadm-control-plane.yaml
@@ -73,6 +73,10 @@ spec:
       controllerManager:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .etcd }}
+      etcd:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     initConfiguration:
       nodeRegistration:

--- a/cluster-api-byoh/values.yaml
+++ b/cluster-api-byoh/values.yaml
@@ -44,6 +44,10 @@ kubeadmControlPlane:
     controllerManager:
       extraArgs:
         enable-hostpath-provisioner: "false" # if kube-vip is enabled, this should also be true.
+    etcd:
+      local:
+        extraArgs:
+          listen-metrics-urls: "http://0.0.0.0:2381"
 
 machineDeployment:
 - name: tks


### PR DESCRIPTION
etcd 메트릭을 외부 노드에서 접근할 수 있도록 바인딩 주소를 설정합니다.