### PR TITLE
feature. add helm network value to cluster-api-aws

### DIFF
--- a/cluster-api-aws/templates/aws-managed-control-plane.yaml
+++ b/cluster-api-aws/templates/aws-managed-control-plane.yaml
@@ -15,6 +15,10 @@ spec:
   identityRef:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.cluster.network}}
+  network:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   bastion:
     enabled: {{ .Values.cluster.bastion.enabled }}
     {{- if .Values.cluster.bastion.enabled  }}


### PR DESCRIPTION
network 섹션에 대한 chart value 가 누락되어 있어, 추가합니다.
기존 cluster-api-aws 에 영향도 없다고 판단되어 버전업하지 않습니다.
