### PR TITLE
lma-addons: add servicemonitor for argo-rollouts

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project
 name: lma-addons
-version: 1.8.6
+version: 1.8.7

--- a/lma-addons/templates/service-monitor/argo-rollouts.yaml
+++ b/lma-addons/templates/service-monitor/argo-rollouts.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.argoRollout.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: rollouts-controller
+    app.kubernetes.io/instance: argo-rollouts
+    app.kubernetes.io/name: argo-rollouts
+  name: argo-rollouts
+  namespace: {{ .Release.Namespace }}
+spec:
+  jobLabel: argo-rollouts
+  namespaceSelector:
+    {{- if .Values.serviceMonitor.argoRollout.targetNamespace }}
+    matchNames:
+    - {{.Values.serviceMonitor.argoRollout.targetNamespace }}
+    {{- else}}
+    any: true
+    {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rollouts-controller
+      app.kubernetes.io/instance: argo-rollouts
+      app.kubernetes.io/name: argo-rollouts
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.argoRollout.interval }}
+    interval: {{ .Values.serviceMonitor.argoRollout.interval }}
+    {{- end }}
+{{- if .Values.serviceMonitor.argoRollout.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.argoRollout.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.argoRollout.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.argoRollout.relabelings | indent 6 }}
+{{- end }}

--- a/lma-addons/values.yaml
+++ b/lma-addons/values.yaml
@@ -58,6 +58,13 @@ serviceMonitor:
     metricRelabelings: []
     relabelings: []
 
+  argoRollout:
+    enabled: false
+    targetNamespace: taco-system
+    # interval: "30s"
+    metricRelabelings: []
+    relabelings: []
+
   argocd:
     enabled: false
     ### interval for scrape


### PR DESCRIPTION
- https://github.com/openinfradev/decapod-base-yaml/pull/304
- https://github.com/openinfradev/helm-charts/pull/223
