### PR TITLE
lma-addons: change metrics to check abnormal status

### DIFF
--- a/lma-addons/Chart.yaml
+++ b/lma-addons/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes Resources for TACO Project
 name: lma-addons
-version: 1.8.7
+version: 1.8.8

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewContainer.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewContainer.json
@@ -23,8 +23,8 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 12611,
   "graphTooltip": 0,
-  "id": 16,
-  "iteration": 1688092237709,
+  "id": 17,
+  "iteration": 1706234186760,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -173,7 +173,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "count((kube_pod_status_ready{condition=\"true\"} == 0) and ON(taco_cluster, namespace, pod) kube_pod_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}) or vector(0)",
+          "expr": "count((kube_pod_status_reason != 0) and ON(taco_cluster, namespace, pod) kube_pod_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}) or vector(0)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -299,7 +299,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "count(kube_pod_container_status_ready == 0 and ON(namespace, pod, container) kube_pod_container_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}) or vector(0)",
+          "expr": "count(kube_pod_container_status_terminated_reason{reason!='Completed'} and ON(namespace, pod, container) kube_pod_container_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}) or vector(0)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -344,32 +344,7 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Restart (1h)"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Running"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
@@ -400,11 +375,25 @@
           "exemplar": false,
           "expr": "label_join((kube_pod_container_status_running == 0 or ON(namespace, pod, container) (increase(kube_pod_container_status_restarts_total[1h]) > 0)), \"key\", \"/\", \"namespace\", \"pod\") and ON(taco_cluster, namespace, pod, container) kube_pod_container_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}",
           "format": "table",
-          "hide": false,
+          "hide": true,
           "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": false,
+          "expr": "sum((kube_pod_container_status_terminated_reason == 1 or ON(taco_cluster, namespace, pod, container) (increase(kube_pod_container_status_restarts_total[1h]) > 0)) and ON(taco_cluster, namespace, pod, container) kube_pod_container_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}) by (taco_cluster, namespace, pod, container, reason)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
         },
         {
           "datasource": {
@@ -421,7 +410,7 @@
           "refId": "C"
         }
       ],
-      "title": "Abnormal Containers",
+      "title": "Terminated Containers",
       "transformations": [
         {
           "id": "seriesToColumns",
@@ -436,6 +425,7 @@
               "Time": true,
               "Time 1": true,
               "Time 2": true,
+              "Value #B": true,
               "__name__": true,
               "container 1": false,
               "container 2": true,
@@ -445,30 +435,21 @@
               "job": true,
               "job 1": true,
               "job 2": true,
-              "namespace": true,
+              "namespace": false,
               "namespace 1": true,
               "namespace 2": true,
-              "pod": true,
+              "pod": false,
               "pod 1": true,
               "pod 2": true
             },
             "indexByName": {
-              "Time 1": 4,
-              "Time 2": 10,
-              "Value #A": 2,
-              "Value #C": 3,
-              "__name__": 5,
-              "container 1": 1,
-              "container 2": 11,
-              "instance 1": 6,
-              "instance 2": 12,
-              "job 1": 7,
-              "job 2": 13,
-              "key": 0,
-              "namespace 1": 8,
-              "namespace 2": 14,
-              "pod 1": 9,
-              "pod 2": 15
+              "Time": 0,
+              "Value #B": 6,
+              "container": 4,
+              "namespace": 2,
+              "pod": 3,
+              "reason": 5,
+              "taco_cluster": 1
             },
             "renameByName": {
               "Time 1": "",
@@ -829,7 +810,7 @@
             "h": 10,
             "w": 8,
             "x": 0,
-            "y": 17
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 35,
@@ -919,7 +900,7 @@
             "h": 10,
             "w": 8,
             "x": 8,
-            "y": 17
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 37,
@@ -1009,7 +990,7 @@
             "h": 10,
             "w": 8,
             "x": 16,
-            "y": 17
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 43,
@@ -1744,7 +1725,7 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1922,7 +1903,7 @@
     ]
   },
   "timezone": "",
-  "title": "[TKS] Kubernetes / View / Container",
+  "title": "[TKS] Kubernetes / Container",
   "uid": "tks_container_dashboard",
   "version": 1,
   "weekStart": ""

--- a/lma-addons/artifacts/dashboard/kubernetes-ViewContainer.json
+++ b/lma-addons/artifacts/dashboard/kubernetes-ViewContainer.json
@@ -24,7 +24,7 @@
   "gnetId": 12611,
   "graphTooltip": 0,
   "id": 17,
-  "iteration": 1706234186760,
+  "iteration": 1706252541414,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1725,22 +1725,21 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "loki",
-          "uid": "P8E80F9AEF21F6940"
-        },
-        "definition": "label_values(cluster)",
+        "definition": "label_values(up, taco_cluster)",
         "hide": 0,
         "includeAll": true,
         "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
-        "query": "label_values(cluster)",
+        "query": {
+          "query": "label_values(up, taco_cluster)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1750,23 +1749,22 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "loki",
-          "uid": "P8E80F9AEF21F6940"
-        },
-        "definition": "label_values({cluster=\"$cluster\"}, kubernetes_namespace_name)",
+        "definition": "label_values(kube_pod_info{taco_cluster=~\"$cluster\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
         "multi": false,
         "name": "kubernetes_namespace_name",
         "options": [],
-        "query": "label_values({cluster=\"$cluster\"}, kubernetes_namespace_name)",
-        "refresh": 2,
+        "query": {
+          "query": "label_values(kube_pod_info{taco_cluster=~\"$cluster\"}, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
@@ -1778,22 +1776,25 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
-        "datasource": {
-          "type": "loki",
-          "uid": "P8E80F9AEF21F6940"
-        },
-        "definition": "label_values({cluster=~\"$cluster\", kubernetes_namespace_name=\"$kubernetes_namespace_name\"}, kubernetes_pod_name)",
+        "definition": "label_values(kube_pod_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\"}, pod)",
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
         "multi": true,
         "name": "kubernetes_pod_name",
         "options": [],
-        "query": "label_values({cluster=~\"$cluster\", kubernetes_namespace_name=\"$kubernetes_namespace_name\"}, kubernetes_pod_name)",
+        "query": {
+          "query": "label_values(kube_pod_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1810,18 +1811,17 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "loki",
-          "uid": "P8E80F9AEF21F6940"
-        },
-        "definition": "label_values({cluster=~\"$cluster\", kubernetes_namespace_name=\"$kubernetes_namespace_name\",kubernetes_pod_name=\"$kubernetes_pod_name\"}, kubernetes_container_name)",
+        "definition": "label_values(kube_pod_container_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}, container)",
         "hide": 0,
         "includeAll": true,
         "label": "Container",
         "multi": false,
         "name": "kubernetes_container_name",
         "options": [],
-        "query": "label_values({cluster=~\"$cluster\", kubernetes_namespace_name=\"$kubernetes_namespace_name\",kubernetes_pod_name=\"$kubernetes_pod_name\"}, kubernetes_container_name)",
+        "query": {
+          "query": "label_values(kube_pod_container_info{taco_cluster=~\"$cluster\", namespace=~\"$kubernetes_namespace_name\", pod=~\"$kubernetes_pod_name\"}, container)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
ready가 아닌 모든 컨테이너를 비정상(abnormal)로 판단하던 로직으로 혼선을 가져왔고 이에 따라 적절한 내역으로 변경함

- pod의 비정상 판단
  - 기존: kube_pod_status_ready{condition=\"true\"} == 0
  - 변경: kube_pod_status_reason != 0
  - pod의 상태가 ready가 아니면 비정상 에서 상태변경에 대한 이유가 있는 파드로 대치, 이유는 다음확인
  Evicted, NodeAffinity, NodeLost, Shutdown, UnexpectedAdmissionError
- 컨테이너의 비정상 판단
  - 기존: kube_pod_container_status_ready == 0. 
  - 변경: kube_pod_container_status_terminated_reason{reason!='Completed'} != 0
  - 컨테이너의 상태가 ready가 아니면 비정상 에서 완료상태가 Completed가 아닌 상황에서 종료한 컨테이너의 수로 변경

이에따라 부가적으로 제공하던 비정상 컨테이너 리스트로 정지상태의 컨테이너와 정지 이유를 전달하는 방식으로 변경 