### PR TITLE
cluster-api-aws: add support for additional security groups

### DIFF
--- a/cluster-api-aws/Chart.yaml
+++ b/cluster-api-aws/Chart.yaml
@@ -4,6 +4,6 @@ description: A chart to install Kubernetes cluster using Cluster API Provider AW
 
 type: application
 
-version: 0.10.0
+version: 0.10.1
 
 appVersion: "2.2.1"

--- a/cluster-api-aws/templates/machine-deployment.yaml
+++ b/cluster-api-aws/templates/machine-deployment.yaml
@@ -10,6 +10,7 @@
 {{- $mdRootVolumeSize := .rootVolume.size }}
 {{- $mdRootVolumeType := .rootVolume.type }}
 {{- $spot := .spotInstance }}
+{{- $additionalSecurityGroups := .additionalSecurityGroups }}
 {{- range untilStep 0 $numAZ 1 }}
 apiVersion: {{ $envAll.Values.api.group.cluster }}/{{ $envAll.Values.api.version }}
 kind: MachineDeployment
@@ -78,6 +79,11 @@ spec:
         - name: "tag-key"
           values:
           - "*{{ $envAll.Values.cluster.name }}*"
+      {{- with .additionalSecurityGroups }}
+      additionalSecurityGroups:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+
 ---
 {{- if $envAll.Values.cluster.eksEnabled }}
 apiVersion: {{ $envAll.Values.api.group.bootstrap }}/{{ $envAll.Values.api.version }}

--- a/cluster-api-aws/templates/machine-pool.yaml
+++ b/cluster-api-aws/templates/machine-pool.yaml
@@ -78,6 +78,10 @@ spec:
     ami:
       {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .additionalSecurityGroups }}
+    additionalSecurityGroups:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
   maxSize: {{ .maxSize }}
   minSize: {{ .minSize }}
   subnets:

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -92,6 +92,7 @@ machinePool: []
 #   labels: []
 #   roleAdditionalPolicies:
 #   - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+#   additionalSecurityGroups: []
 # **this version dosen't support the spot instance, because the aws cluster api provider doesn't support it in awsmachinpool**
 # useSpotInstance:  #spotMarketOptions:
 #   enabled: false
@@ -106,6 +107,7 @@ machinePool: []
 #     size: 8
 #   subnets: []
 #   labels: []
+#   additionalSecurityGroups: []
 
 machineDeployment: []
 # You can define machineDeployment to use cluster-autoscaler on aws. referce the belows.
@@ -123,6 +125,7 @@ machineDeployment: []
 #     enabled: true
 #     maxPrice: ''
 #     # MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
+#   additionalSecurityGroups: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
워커 노드에 사용자 정의 SecurityGroup 추가를 위한 변경입니다. (SKB DR 환경 필요 사항)