### PR TITLE
cluster-api-aws: add support for additional security groups to control plane nodes

### DIFF
--- a/cluster-api-aws/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-aws/templates/kubeadm-control-plane.yaml
@@ -59,4 +59,8 @@ spec:
       ami:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kubeadmControlPlane.additionalSecurityGroups }}
+      additionalSecurityGroups:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -62,6 +62,7 @@ kubeadmControlPlane:
     type: gp3
   # ami:
   #   id: ami-xxxxxxxxxxxxxxxxx
+  # additionalSecurityGroups: []
   useSpotInstance: #spotMarketOptions:
     enabled: false
     maxPrice: ""


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/pull/230 에서 이어서 컨트롤 플레인 노드 역시 SecurityGroup 추가가 가능하도록 수정하였습니다.
