### PR TITLE
github workflow: lint:  use latest helm for lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Helm
         uses: azure/setup-helm@v1
-        with:
-          version: v3.5.0
       - name: Lint charts
         run: |
             for dir in $(find . -type d -mindepth 1 -maxdepth 1); do


### PR DESCRIPTION
Helm 버전을 최신 버전으로 Lint 과정에 사용합니다.

```
- uses: azure/setup-helm@v4.1.0
  with:
     version: '<version>' # default is latest (stable)
  id: install
```