### PR TITLE
cluster-api-byoh: add custom container registry for k8s images

### DIFF
--- a/cluster-api-byoh/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-byoh/templates/kubeadm-control-plane.yaml
@@ -77,6 +77,7 @@ spec:
       etcd:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      imageRepository: {{ .imageRepository }}
     {{- end }}
     initConfiguration:
       nodeRegistration:

--- a/cluster-api-byoh/values.yaml
+++ b/cluster-api-byoh/values.yaml
@@ -1,9 +1,9 @@
 cluster:
   name: byoh-cluster
   podCidrBlocks:
-  - 10.233.64.0/18
+    - 10.233.64.0/18
   serviceCidrBlocks:
-  - 10.233.0.0/18
+    - 10.233.0.0/18
   kubernetesVersion: v1.23.5
 
 kubeVip:
@@ -32,9 +32,9 @@ kubeadmControlPlane:
   clusterConfiguration:
     apiServer:
       certSANs:
-      - localhost
-      - 127.0.0.1
-      - 0.0.0.0
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
       extraArgs:
         oidc-client-id: kubernetes
         oidc-groups-claim: groups
@@ -48,27 +48,30 @@ kubeadmControlPlane:
       local:
         extraArgs:
           listen-metrics-urls: "http://0.0.0.0:2381"
+        imageRepository: "registry.k8s.io"
+        imageTag: "3.5.10-0"
+    imageRepository: "registry.k8s.io"
 
 machineDeployment:
-- name: tks
-  replicas: 1
-  selector:
-    matchLabels:
-      role: tks
-  labels:
-    servicemesh: enabled
-    taco-egress-gateway: enabled
-    taco-ingress-gateway: enabled
-    taco-lma: enabled
+  - name: tks
+    replicas: 1
+    selector:
+      matchLabels:
+        role: tks
+    labels:
+      servicemesh: enabled
+      taco-egress-gateway: enabled
+      taco-ingress-gateway: enabled
+      taco-lma: enabled
 
-- name: normal
-  replicas: 1
-  autoscaling:
-    minSize: 1
-    maxSize: 5
-  selector:
-    matchLabels:
-      role: worker
+  - name: normal
+    replicas: 1
+    autoscaling:
+      minSize: 1
+      maxSize: 5
+    selector:
+      matchLabels:
+        role: worker
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
BYOH 프로바이더 Airgap 지원 사항입니다.
공식 이미지 저장소가 아닌 별도의 컨테이너 레지스트리를 이용하여 클러스터 구성 가능하도록 K8S 이미지들 (kube-api, controller-mananger, etcd 등)의 컨테이너 레지스트리 저장소 주소를 설정할 수 있도록 수정하였습니다.