### PR TITLE
cluster-api-aws: use external cloud provider

### DIFF
--- a/cluster-api-aws/Chart.yaml
+++ b/cluster-api-aws/Chart.yaml
@@ -4,6 +4,6 @@ description: A chart to install Kubernetes cluster using Cluster API Provider AW
 
 type: application
 
-version: 0.10.1
+version: 0.11.1
 
 appVersion: "2.2.1"

--- a/cluster-api-aws/templates/cluster.yaml
+++ b/cluster-api-aws/templates/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: {{ .Values.api.group.cluster }}/{{ .Values.api.version }}
 kind: Cluster
 metadata:
+  labels:
+    ccm: external
+    csi: external
   name: {{ .Values.cluster.name }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/cluster-api-aws/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-aws/templates/kubeadm-control-plane.yaml
@@ -33,12 +33,12 @@ spec:
       nodeRegistration:
         name: '{{`{{ ds.meta_data.local_hostname }}`}}'
         kubeletExtraArgs:
-          cloud-provider: aws
+          cloud-provider: external
     joinConfiguration:
       nodeRegistration:
         name: '{{`{{ ds.meta_data.local_hostname }}`}}'
         kubeletExtraArgs:
-          cloud-provider: aws
+          cloud-provider: external
   version: {{ .Values.cluster.kubernetesVersion }}
 ---
 apiVersion: {{ .Values.api.group.infrastructure }}/v1beta2

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -70,10 +70,10 @@ kubeadmControlPlane:
   clusterConfiguration:
     apiServer:
       extraArgs:
-        cloud-provider: aws # must be defined
+        cloud-provider: external # must be defined
     controllerManager:
       extraArgs:
-        cloud-provider: aws # must be defined
+        cloud-provider: external # must be defined
     etcd:
       local:
         extraArgs:
@@ -116,7 +116,7 @@ machineDeployment: []
 #   minSizePerAZ: 1
 #   maxSizePerAZ: 3
 #   selector:
-#     matchLabels:
+#     matchLabels: null
 #   machineType: t3.large
 #   rootVolume:
 #     size: 20


### PR DESCRIPTION
cloud provider controller mananger를 독립된 구현체를 사용하도록 합니다. (v1.27 부터 AWS 는 내장 코드가 제거됨)