### PR TITLE
cluster-api-aws: fix AMI specification errors

### DIFF
--- a/cluster-api-aws/templates/kubeadm-control-plane.yaml
+++ b/cluster-api-aws/templates/kubeadm-control-plane.yaml
@@ -55,7 +55,7 @@ spec:
       rootVolume:
         size: {{ .Values.kubeadmControlPlane.rootVolume.size }}
         type: {{ .Values.kubeadmControlPlane.rootVolume.type }}
-      {{- if .Values.kubeadmControlPlane.ami }}
+      {{- with .Values.kubeadmControlPlane.ami }}
       ami:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/cluster-api-aws/templates/machine-deployment.yaml
+++ b/cluster-api-aws/templates/machine-deployment.yaml
@@ -83,6 +83,11 @@ spec:
       additionalSecurityGroups:
         {{- toYaml . | nindent 10 }}
       {{- end }}
+      {{- with .ami }}
+      ami:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+
 
 ---
 {{- if $envAll.Values.cluster.eksEnabled }}

--- a/cluster-api-aws/templates/machine-pool.yaml
+++ b/cluster-api-aws/templates/machine-pool.yaml
@@ -74,7 +74,7 @@ spec:
     rootVolume:
       size: {{ .rootVolume.size }}
       type: {{ .rootVolume.type }}
-    {{- if .ami }}
+    {{- with .ami }}
     ami:
       {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/cluster-api-aws/values.yaml
+++ b/cluster-api-aws/values.yaml
@@ -61,7 +61,7 @@ kubeadmControlPlane:
     size: 8
     type: gp3
   # ami:
-  #   id: ami-xxxxxxxxxxxxxxxxx
+  #   id: ami-02e4e8f09921cfe97
   # additionalSecurityGroups: []
   useSpotInstance: #spotMarketOptions:
     enabled: false
@@ -93,6 +93,7 @@ machinePool: []
 #   roleAdditionalPolicies:
 #   - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 #   additionalSecurityGroups: []
+#   ami: ami-02e4e8f09921cfe97
 # **this version dosen't support the spot instance, because the aws cluster api provider doesn't support it in awsmachinpool**
 # useSpotInstance:  #spotMarketOptions:
 #   enabled: false
@@ -108,6 +109,7 @@ machinePool: []
 #   subnets: []
 #   labels: []
 #   additionalSecurityGroups: []
+#   ami: ami-02e4e8f09921cfe97
 
 machineDeployment: []
 # You can define machineDeployment to use cluster-autoscaler on aws. Refer to below.
@@ -126,6 +128,7 @@ machineDeployment: []
 #     maxPrice: ''
 #     # MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
 #   additionalSecurityGroups: []
+#   ami: ami-02e4e8f09921cfe97
 
 machineKubeadmConfig:
   kubeletExtraArgs: {}


### PR DESCRIPTION
AMI 지정 오류 수정하였습니다.

아래는 테스트에 사용한 value 입니다.
```
machineKubeadmConfig:
  kubeletExtraArgs:
    max-pods: 110
    feature-gates: "InPlacePodVerticalScaling=true"

machinePool:
  - name: taco
    machineType: t3.2xlarge
    replicas: 3
    minSize: 1
    maxSize: 10
    rootVolume:
      size: 200
    subnets: []
    labels: []
    roleAdditionalPolicies:
      - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
    additionalSecurityGroups: []
    ami: ami-02e4e8f09921cfe97

machineDeployment:
  - name: normal
    numberOfAZ: 3
    minSizePerAZ: 1
    maxSizePerAZ: 3
    selector:
      matchLabels: null
    machineType: t3.large
    rootVolume:
      size: 20
      type: gp3
    ami: ami-02e4e8f09921cfe97

kubeadmControlPlane:
  ami:
    id: ami-02e4e8f09921cfe97
```

결과
```
# Source: cluster-api-aws/templates/machine-pool.yaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: AWSMachinePool
metadata:
  name: capi-quickstart-mp-taco
  namespace: default
spec:
  awsLaunchTemplate:
    instanceType: t3.2xlarge
    sshKeyName: default
    iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
    rootVolume:
      size: 200
      type:
    ami:
        ami-02e4e8f09921cfe97
  maxSize: 10
  minSize: 1
  subnets:
  - filters:
    - name: "tag:sigs.k8s.io/cluster-api-provider-aws/role"
      values:
      - "private"
    - name: "tag:Name"
      values:
      - "*capi-quickstart*"
---
# Source: cluster-api-aws/templates/kubeadm-control-plane.yaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: AWSMachineTemplate
metadata:
  name: capi-quickstart-control-plane
  namespace: default
spec:
  template:
    spec:
      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
      instanceType: t3.large
      sshKeyName: default
      rootVolume:
        size: 8
        type: gp3
      ami:
        id: ami-02e4e8f09921cfe97
---
# Source: cluster-api-aws/templates/machine-deployment.yaml
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: AWSMachineTemplate
metadata:
  name: capi-quickstart-md-normal
  namespace: default
spec:
  template:
    spec:
      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
      instanceType: t3.large
      sshKeyName: default
      rootVolume:
        size: 20
        type: gp3
      subnet:
        filters:
        - name: "tag:sigs.k8s.io/cluster-api-provider-aws/role"
          values:
          - "private"
        - name: "tag-key"
          values:
          - "*capi-quickstart*"
      ami:
          ami-02e4e8f09921cfe97
```